### PR TITLE
Add skeleton desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ If you are interested in including a link on nyano.org, please list it here firs
 
 ## installation
 npm install
+## Desktop wallet
+See [linux-desktop](linux-desktop/) for an Electron-based starter wallet and miner.
+
+```
+cd linux-desktop
+npm install
+npm start
+```

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -1,0 +1,18 @@
+# Nyano Desktop
+
+This directory contains a minimal Electron application that serves as the foundation for a Nyano desktop wallet and mining interface for Linux. It currently demonstrates a basic window and preload script.
+
+## Install dependencies
+
+```
+cd linux-desktop
+npm install
+```
+
+## Run the app
+
+```
+npm start
+```
+
+This is a starting point. Future work can integrate wallet functionality, mining controls, and additional features inspired by platforms like Kraken.

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Nyano Desktop</title>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; }
+    h1 { color: #333; }
+  </style>
+</head>
+<body>
+  <h1>Welcome to Nyano Desktop</h1>
+  <p>Platform: <span id="platform"></span></p>
+  <script>
+    document.getElementById('platform').textContent = window.nyano.platform;
+  </script>
+</body>
+</html>

--- a/linux-desktop/main.js
+++ b/linux-desktop/main.js
@@ -1,0 +1,26 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/linux-desktop/package.json
+++ b/linux-desktop/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nyano-desktop",
+  "version": "0.1.0",
+  "description": "Nyano desktop wallet and miner",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^37.2.4"
+  }
+}

--- a/linux-desktop/preload.js
+++ b/linux-desktop/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge } = require('electron');
+
+contextBridge.exposeInMainWorld('nyano', {
+  platform: process.platform
+});


### PR DESCRIPTION
## Summary
- add `linux-desktop` folder with minimal Electron app for a future wallet/miner
- update README with instructions for the desktop wallet

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a912e9dc8832fb42ea9b6ddd2522d