### PR TITLE
Add transaction history to Linux desktop wallet

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -6,7 +6,8 @@ navigation bar with separate pages for **Wallet**, **Miner**, and
 **Settings**. The platform information and application version are exposed via a
 preload API and shown on the settings page. The wallet view includes a simple
 send form and address display, while the miner page provides start/stop controls.
-A dark mode toggle is also available in the settings.
+A dark mode toggle is also available in the settings. Sent transactions are
+tracked locally and shown in a simple history table within the wallet view.
 
 ## Install dependencies
 

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -44,6 +44,21 @@
           <button id="send-button">Send</button>
           <div id="tx-status" class="status"></div>
         </div>
+
+        <div class="history">
+          <h3>Transaction History</h3>
+          <table id="history-table">
+            <thead>
+              <tr>
+                <th>To</th>
+                <th>Amount</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <button id="clear-history">Clear History</button>
+        </div>
       </section>
 
       <section id="miner" class="page">

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -62,12 +62,57 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const sendBtn = document.getElementById('send-button');
+  const historyTable = document.getElementById('history-table');
+  const clearHistoryBtn = document.getElementById('clear-history');
+  let history = [];
+
+  const loadHistory = () => {
+    try {
+      const stored = localStorage.getItem('history');
+      history = stored ? JSON.parse(stored) : [];
+    } catch {
+      history = [];
+    }
+  };
+
+  const saveHistory = () => {
+    localStorage.setItem('history', JSON.stringify(history));
+  };
+
+  const renderHistory = () => {
+    if (!historyTable) return;
+    const tbody = historyTable.querySelector('tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    history.forEach(tx => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${tx.to}</td><td>${tx.amount}</td><td>${tx.date}</td>`;
+      tbody.appendChild(row);
+    });
+  };
+
+  loadHistory();
+  renderHistory();
+
   if (sendBtn) {
     sendBtn.addEventListener('click', () => {
       const to = document.getElementById('send-to').value;
       const amt = document.getElementById('send-amount').value;
       const status = document.getElementById('tx-status');
       status.textContent = `Pretending to send ${amt} NYANO to ${to}`;
+
+      const tx = { to, amount: amt, date: new Date().toLocaleString() };
+      history.unshift(tx);
+      saveHistory();
+      renderHistory();
+    });
+  }
+
+  if (clearHistoryBtn) {
+    clearHistoryBtn.addEventListener('click', () => {
+      history = [];
+      saveHistory();
+      renderHistory();
     });
   }
 

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -118,3 +118,23 @@ header {
   font-size: 0.9rem;
   color: #555;
 }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #ccc;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+th {
+  background: #eee;
+}
+
+.dark th {
+  background: #333;
+}


### PR DESCRIPTION
## Summary
- extend the wallet page with a transaction history table and Clear History button
- persist history in `localStorage`
- wire up history logic in renderer
- style the history table
- update documentation with info about the new feature

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a97f9a648832f833a9f2445b623c1