### PR TITLE
Add dashboard to desktop UI

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -2,8 +2,8 @@
 
 This directory contains a small Electron application that acts as the starting
 point for a Nyano desktop wallet and miner. The interface uses a left side
-navigation bar with separate pages for **Wallet**, **Miner**, and
-**Settings**. The platform information and application version are exposed via a
+navigation bar with separate pages for **Wallet**, **Dashboard**, **Miner**, and
+**Settings**. The Dashboard fetches the current Nano price and basic network status. The platform information and application version are exposed via a
 preload API and shown on the settings page. The wallet view includes a simple
 send form and address display, while the miner page provides start/stop controls.
 A dark mode toggle is also available in the settings. Sent transactions are

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -18,6 +18,9 @@
         <li data-page="wallet" class="active">
           <i class="fas fa-wallet"></i> Wallet
         </li>
+        <li data-page="dashboard">
+          <i class="fas fa-chart-line"></i> Dashboard
+        </li>
         <li data-page="miner">
           <i class="fas fa-coins"></i> Miner
         </li>
@@ -59,6 +62,13 @@
           </table>
           <button id="clear-history">Clear History</button>
         </div>
+      </section>
+
+      <section id="dashboard" class="page">
+        <h2>Dashboard</h2>
+        <div class="price">NANO Price: <span id="nano-price">loading...</span> USD</div>
+        <div class="network">Network Status: <span id="network-status">checking...</span></div>
+        <button id="refresh-dashboard">Refresh</button>
       </section>
 
       <section id="miner" class="page">

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -142,5 +142,30 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   updateMinerUI();
+
+  // Dashboard data
+  const priceEl = document.getElementById('nano-price');
+  const networkEl = document.getElementById('network-status');
+  const refreshBtn = document.getElementById('refresh-dashboard');
+
+  const fetchDashboard = async () => {
+    if (priceEl) priceEl.textContent = 'loading...';
+    if (networkEl) networkEl.textContent = 'checking...';
+    try {
+      const resp = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=nano&vs_currencies=usd');
+      const data = await resp.json();
+      if (priceEl) priceEl.textContent = data.nano.usd;
+      if (networkEl) networkEl.textContent = 'online';
+    } catch (err) {
+      if (priceEl) priceEl.textContent = 'error';
+      if (networkEl) networkEl.textContent = 'offline';
+    }
+  };
+
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', fetchDashboard);
+  }
+
+  fetchDashboard();
 });
 

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -91,6 +91,11 @@ header {
   margin-bottom: 20px;
 }
 
+.price,
+.network {
+  margin-bottom: 10px;
+}
+
 .wallet-address input {
   width: calc(100% - 70px);
   padding: 6px;


### PR DESCRIPTION
## Summary
- show Dashboard link in sidebar navigation
- display NANO price and network status
- add styles for new dashboard page
- document Dashboard page in the desktop README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688aa781a30c832f8e399a8a2c57b245