### PR TITLE
Add seed management and network settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ If you are interested in including a link on nyano.org, please list it here firs
 ## installation
 npm install
 ## Desktop wallet
-See [linux-desktop](linux-desktop/) for an Electron-based starter wallet and miner.
+See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.
+The app now includes seed management and network selection on the settings page.
 
 ```
 cd linux-desktop

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -9,6 +9,11 @@ send form and address display, while the miner page provides start/stop controls
 A dark mode toggle is also available in the settings. Sent transactions are
 tracked locally and shown in a simple history table within the wallet view.
 
+Recent updates introduce basic wallet management. You can generate or import a
+seed on the **Settings** page and select which network (mainnet, testnet, or
+beta) the app should target. The derived Nyano address is displayed in the
+wallet view along with a QR code.
+
 ## Install dependencies
 
 ```

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -88,6 +88,23 @@
         <label class="toggle">
           <input type="checkbox" id="dark-toggle" /> Dark mode
         </label>
+        <div class="seed-settings">
+          <h3>Wallet Seed</h3>
+          <input type="password" id="seed-input" placeholder="Enter seed" />
+          <button id="toggle-seed" title="Show/Hide">
+            <i class="fas fa-eye"></i>
+          </button>
+          <button id="generate-seed">Generate</button>
+          <button id="save-seed">Save</button>
+        </div>
+        <div class="network-settings">
+          <h3>Network</h3>
+          <select id="network-select">
+            <option value="mainnet">Mainnet</option>
+            <option value="testnet">Testnet</option>
+            <option value="beta">Beta</option>
+          </select>
+        </div>
         <p>Platform: <span id="platform"></span></p>
         <p>Version: <span id="version"></span></p>
       </section>

--- a/linux-desktop/package.json
+++ b/linux-desktop/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.0.0",
     "electron": "^37.2.4",
+    "nanocurrency": "^2.5.0",
     "qrcode": "^1.5.1"
   }
 }

--- a/linux-desktop/preload.js
+++ b/linux-desktop/preload.js
@@ -1,7 +1,11 @@
 const { contextBridge } = require('electron');
 const { version } = require('./package.json');
+const { generateSeed, deriveAddress } = require('nanocurrency');
 
 contextBridge.exposeInMainWorld('nyano', {
   platform: process.platform,
-  version
+  version,
+  generateSeed,
+  deriveAddress: (seed, index = 0) =>
+    deriveAddress(seed, index, { prefix: 'nyano_' })
 });

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -40,8 +40,57 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Wallet placeholder data
-  const address = 'nyano_111111111111111111111111111111111111111111111111111111111111';
+  // Seed and network settings
+  const seedInput = document.getElementById('seed-input');
+  const toggleSeedBtn = document.getElementById('toggle-seed');
+  const generateSeedBtn = document.getElementById('generate-seed');
+  const saveSeedBtn = document.getElementById('save-seed');
+  const networkSelect = document.getElementById('network-select');
+
+  const storedSeed = localStorage.getItem('seed') || '';
+  if (seedInput) seedInput.value = storedSeed;
+  const storedNetwork = localStorage.getItem('network') || 'mainnet';
+  if (networkSelect) networkSelect.value = storedNetwork;
+
+  const updateAddress = () => {
+    if (!seedInput) return;
+    const seed = seedInput.value.trim();
+    if (!seed) return;
+    const addr = window.nyano.deriveAddress(seed, 0);
+    address = addr;
+    if (addressEl) addressEl.value = addr;
+    if (qrCanvas && typeof QRCode !== 'undefined') {
+      QRCode.toCanvas(qrCanvas, addr, { margin: 1 }, () => {});
+    }
+  };
+
+  if (toggleSeedBtn && seedInput) {
+    toggleSeedBtn.addEventListener('click', () => {
+      seedInput.type = seedInput.type === 'password' ? 'text' : 'password';
+    });
+  }
+
+  if (generateSeedBtn && seedInput) {
+    generateSeedBtn.addEventListener('click', () => {
+      seedInput.value = window.nyano.generateSeed();
+    });
+  }
+
+  if (saveSeedBtn && seedInput) {
+    saveSeedBtn.addEventListener('click', () => {
+      localStorage.setItem('seed', seedInput.value.trim());
+      updateAddress();
+    });
+  }
+
+  if (networkSelect) {
+    networkSelect.addEventListener('change', () => {
+      localStorage.setItem('network', networkSelect.value);
+    });
+  }
+
+  // Wallet data
+  let address = storedSeed ? window.nyano.deriveAddress(storedSeed, 0) : "nyano_11111111111111111111111111111111111111111111111111111111111";
   const balanceEl = document.getElementById('balance');
   const addressEl = document.getElementById('address');
   const qrCanvas = document.getElementById('address-qr');
@@ -54,10 +103,12 @@ window.addEventListener('DOMContentLoaded', () => {
   if (qrCanvas && typeof QRCode !== 'undefined') {
     QRCode.toCanvas(qrCanvas, address, { margin: 1 }, function () {});
   }
+  if (storedSeed) updateAddress();
 
   const copyBtn = document.getElementById('copy-address');
   if (copyBtn) {
     copyBtn.addEventListener('click', () => {
+      updateAddress();
       navigator.clipboard.writeText(address).then(() => {
         copyBtn.textContent = 'Copied!';
         setTimeout(() => (copyBtn.textContent = ''), 1000);

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -148,3 +148,18 @@ th {
   margin-top: 10px;
   display: block;
 }
+
+.seed-settings,
+.network-settings {
+  margin: 20px 0;
+}
+
+.seed-settings input {
+  width: 300px;
+  padding: 6px;
+}
+
+.seed-settings button {
+  margin-left: 4px;
+  padding: 6px 10px;
+}


### PR DESCRIPTION
## Summary
- extend `linux-desktop` Electron app with seed and network controls
- expose `nanocurrency` helpers in preload
- update wallet UI to allow generating/importing seed and selecting network
- enhance README docs

## Testing
- `npm start` *(fails: libatk-1.0.so.0 missing)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688aad8c2598832f8ae6e553174b26f8