### PR TITLE
Add contacts management page

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -14,6 +14,10 @@ seed on the **Settings** page and select which network (mainnet, testnet, or
 beta) the app should target. The derived Nyano address is displayed in the
 wallet view along with a QR code.
 
+You can now manage saved addresses on the **Contacts** page. Stored contacts
+let you quickly fill the send form in the wallet view and are persisted in the
+browser's local storage.
+
 ## Install dependencies
 
 ```

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -18,6 +18,9 @@
         <li data-page="wallet" class="active">
           <i class="fas fa-wallet"></i> Wallet
         </li>
+        <li data-page="contacts">
+          <i class="fas fa-address-book"></i> Contacts
+        </li>
         <li data-page="dashboard">
           <i class="fas fa-chart-line"></i> Dashboard
         </li>
@@ -64,6 +67,21 @@
           <button id="clear-history">Clear History</button>
           <button id="export-history">Export CSV</button>
         </div>
+      </section>
+
+      <section id="contacts" class="page">
+        <h2>Contacts</h2>
+        <div class="add-contact">
+          <input type="text" id="contact-name" placeholder="Name" />
+          <input type="text" id="contact-address" placeholder="Nyano address" />
+          <button id="add-contact">Add</button>
+        </div>
+        <table id="contacts-table">
+          <thead>
+            <tr><th>Name</th><th>Address</th><th></th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </section>
 
       <section id="dashboard" class="page">

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -191,6 +191,75 @@ window.addEventListener('DOMContentLoaded', () => {
     exportHistoryBtn.addEventListener('click', exportHistory);
   }
 
+  // Contacts
+  const contactsTable = document.getElementById('contacts-table');
+  const addContactBtn = document.getElementById('add-contact');
+  const contactNameInput = document.getElementById('contact-name');
+  const contactAddressInput = document.getElementById('contact-address');
+  let contacts = [];
+
+  const loadContacts = () => {
+    try {
+      const stored = localStorage.getItem('contacts');
+      contacts = stored ? JSON.parse(stored) : [];
+    } catch {
+      contacts = [];
+    }
+  };
+
+  const saveContacts = () => {
+    localStorage.setItem('contacts', JSON.stringify(contacts));
+  };
+
+  const renderContacts = () => {
+    if (!contactsTable) return;
+    const tbody = contactsTable.querySelector('tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    contacts.forEach((c, i) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${c.name}</td><td>${c.address}</td><td><button data-idx="${i}" class="use-contact">Use</button> <button data-idx="${i}" class="delete-contact">Delete</button></td>`;
+      tbody.appendChild(row);
+    });
+
+    tbody.querySelectorAll('.use-contact').forEach(btn => {
+      btn.addEventListener('click', e => {
+        const idx = e.target.getAttribute('data-idx');
+        const addr = contacts[idx].address;
+        const sendInput = document.getElementById('send-to');
+        if (sendInput) sendInput.value = addr;
+        sidebarItems.forEach(i => {
+          if (i.getAttribute('data-page') === 'wallet') i.click();
+        });
+      });
+    });
+
+    tbody.querySelectorAll('.delete-contact').forEach(btn => {
+      btn.addEventListener('click', e => {
+        const idx = e.target.getAttribute('data-idx');
+        contacts.splice(idx, 1);
+        saveContacts();
+        renderContacts();
+      });
+    });
+  };
+
+  loadContacts();
+  renderContacts();
+
+  if (addContactBtn) {
+    addContactBtn.addEventListener('click', () => {
+      const name = contactNameInput.value.trim();
+      const addr = contactAddressInput.value.trim();
+      if (!name || !addr) return;
+      contacts.push({ name, address: addr });
+      saveContacts();
+      renderContacts();
+      contactNameInput.value = '';
+      contactAddressInput.value = '';
+    });
+  }
+
   // Miner controls
   let mining = false;
   let startTime = 0;

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -163,3 +163,16 @@ th {
   margin-left: 4px;
   padding: 6px 10px;
 }
+
+.add-contact {
+  margin-bottom: 20px;
+}
+
+.add-contact input {
+  padding: 6px;
+  margin-right: 4px;
+}
+
+.add-contact button {
+  padding: 6px 10px;
+}


### PR DESCRIPTION
## Summary
- extend desktop wallet navigation with a new **Contacts** page
- implement contacts storage and quick fill of the send form
- style contacts page and document the feature

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ab39e947c832fab599265bc134be7