### PR TITLE
Add RPC configuration and build script

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -18,6 +18,10 @@ You can now manage saved addresses on the **Contacts** page. Stored contacts
 let you quickly fill the send form in the wallet view and are persisted in the
 browser's local storage.
 
+The settings page also lets you configure the RPC endpoint used for network
+requests. By default the application targets `https://rpc.nyano.org` but you
+can update the URL to point to any compatible node.
+
 ## Install dependencies
 
 ```
@@ -29,6 +33,12 @@ npm install
 
 ```
 npm start
+```
+
+## Build a package
+
+```bash
+npm run build
 ```
 
 This is a starting point. Future work can integrate wallet functionality, mining controls, and additional features inspired by platforms like Kraken. The interface uses Font Awesome icons bundled via `npm`.

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -123,6 +123,11 @@
             <option value="beta">Beta</option>
           </select>
         </div>
+        <div class="rpc-settings">
+          <h3>RPC Endpoint</h3>
+          <input type="text" id="rpc-url" placeholder="https://rpc.nyano.org" />
+          <button id="save-rpc">Save</button>
+        </div>
         <p>Platform: <span id="platform"></span></p>
         <p>Version: <span id="version"></span></p>
       </section>

--- a/linux-desktop/package.json
+++ b/linux-desktop/package.json
@@ -4,12 +4,16 @@
   "description": "Nyano desktop wallet and miner",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "build": "electron-packager . NyanoDesktop --overwrite"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.0.0",
     "electron": "^37.2.4",
     "nanocurrency": "^2.5.0",
     "qrcode": "^1.5.1"
+  },
+  "devDependencies": {
+    "electron-packager": "^17.1.2"
   }
 }

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -46,11 +46,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const generateSeedBtn = document.getElementById('generate-seed');
   const saveSeedBtn = document.getElementById('save-seed');
   const networkSelect = document.getElementById('network-select');
+  const rpcInput = document.getElementById('rpc-url');
+  const saveRpcBtn = document.getElementById('save-rpc');
 
   const storedSeed = localStorage.getItem('seed') || '';
   if (seedInput) seedInput.value = storedSeed;
   const storedNetwork = localStorage.getItem('network') || 'mainnet';
   if (networkSelect) networkSelect.value = storedNetwork;
+  const storedRpc = localStorage.getItem('rpcUrl') || 'https://rpc.nyano.org';
+  if (rpcInput) rpcInput.value = storedRpc;
 
   const updateAddress = () => {
     if (!seedInput) return;
@@ -88,6 +92,14 @@ window.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('network', networkSelect.value);
     });
   }
+
+  if (saveRpcBtn && rpcInput) {
+    saveRpcBtn.addEventListener('click', () => {
+      localStorage.setItem('rpcUrl', rpcInput.value.trim());
+    });
+  }
+
+  const getRpcUrl = () => (rpcInput ? rpcInput.value.trim() : storedRpc);
 
   // Wallet data
   let address = storedSeed ? window.nyano.deriveAddress(storedSeed, 0) : "nyano_11111111111111111111111111111111111111111111111111111111111";
@@ -317,9 +329,18 @@ window.addEventListener('DOMContentLoaded', () => {
       const resp = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=nano&vs_currencies=usd');
       const data = await resp.json();
       if (priceEl) priceEl.textContent = data.nano.usd;
-      if (networkEl) networkEl.textContent = 'online';
     } catch (err) {
       if (priceEl) priceEl.textContent = 'error';
+    }
+    try {
+      const rpcResp = await fetch(getRpcUrl(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'version' })
+      });
+      await rpcResp.json();
+      if (networkEl) networkEl.textContent = 'online';
+    } catch (err) {
       if (networkEl) networkEl.textContent = 'offline';
     }
   };

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -176,3 +176,17 @@ th {
 .add-contact button {
   padding: 6px 10px;
 }
+
+.rpc-settings {
+  margin: 20px 0;
+}
+
+.rpc-settings input {
+  width: 300px;
+  padding: 6px;
+  margin-right: 4px;
+}
+
+.rpc-settings button {
+  padding: 6px 10px;
+}


### PR DESCRIPTION
## Summary
- tweak Settings page UI to include RPC endpoint field
- support saving RPC URL in localStorage
- check RPC connectivity on Dashboard refresh
- provide build script using `electron-packager`
- document new RPC settings and build instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd linux-desktop && npm test` *(fails: Missing script)*
- `cd linux-desktop && npm install --save-dev electron-packager`

------
https://chatgpt.com/codex/tasks/task_e_688ab67bf470832fb54ca501911e3a80