### PR TITLE
Add contact editing in desktop wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ If you are interested in including a link on nyano.org, please list it here firs
 npm install
 ## Desktop wallet
 See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.
-The app now includes seed management and network selection on the settings page.
+The app now includes seed management, network selection on the settings page and a contacts view
+where addresses can be added, edited or removed.
 
 ```
 cd linux-desktop

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -16,7 +16,8 @@ wallet view along with a QR code.
 
 You can now manage saved addresses on the **Contacts** page. Stored contacts
 let you quickly fill the send form in the wallet view and are persisted in the
-browser's local storage.
+browser's local storage. Contacts can be edited or removed at any time using the
+actions in the table.
 
 The settings page also lets you configure the RPC endpoint used for network
 requests. By default the application targets `https://rpc.nyano.org` but you

--- a/linux-desktop/package.json
+++ b/linux-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyano-desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Nyano desktop wallet and miner",
   "main": "main.js",
   "scripts": {

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -280,7 +280,7 @@ window.addEventListener('DOMContentLoaded', () => {
     tbody.innerHTML = '';
     contacts.forEach((c, i) => {
       const row = document.createElement('tr');
-      row.innerHTML = `<td>${c.name}</td><td>${c.address}</td><td><button data-idx="${i}" class="use-contact">Use</button> <button data-idx="${i}" class="delete-contact">Delete</button></td>`;
+      row.innerHTML = `<td>${c.name}</td><td>${c.address}</td><td><button data-idx="${i}" class="use-contact">Use</button> <button data-idx="${i}" class="edit-contact">Edit</button> <button data-idx="${i}" class="delete-contact">Delete</button></td>`;
       tbody.appendChild(row);
     });
 
@@ -293,6 +293,20 @@ window.addEventListener('DOMContentLoaded', () => {
         sidebarItems.forEach(i => {
           if (i.getAttribute('data-page') === 'wallet') i.click();
         });
+      });
+    });
+
+    tbody.querySelectorAll('.edit-contact').forEach(btn => {
+      btn.addEventListener('click', e => {
+        const idx = e.target.getAttribute('data-idx');
+        const c = contacts[idx];
+        const name = prompt('Edit name', c.name);
+        if (name === null) return;
+        const addr = prompt('Edit address', c.address);
+        if (addr === null) return;
+        contacts[idx] = { name: name.trim(), address: addr.trim() };
+        saveContacts();
+        renderContacts();
       });
     });
 


### PR DESCRIPTION
## Summary
- update README with contacts info
- document contact editing in `linux-desktop` readme
- bump desktop wallet version to 0.3.0
- allow editing saved contacts in the desktop wallet

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in linux-desktop *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688abc2c6df8832f8ffa94cb94edbcc4