### PR TITLE
Improve desktop wallet history

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -23,6 +23,10 @@ Contacts can also be imported from or exported to a JSON file using the
 **Import** and **Export** buttons. This makes it easy to back up your saved
 addresses or move them between computers.
 
+The wallet page can now fetch and display your account history from the
+configured RPC endpoint. Click **Refresh** in the history section to load the
+latest 20 transactions from the network.
+
 The settings page also lets you configure the RPC endpoint used for network
 requests. By default the application targets `https://rpc.nyano.org` but you
 can update the URL to point to any compatible node.

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -73,6 +73,21 @@
           <button id="clear-history">Clear History</button>
           <button id="export-history">Export CSV</button>
         </div>
+
+        <div class="network-history">
+          <h3>Account History</h3>
+          <button id="refresh-network-history">Refresh</button>
+          <table id="network-history-table">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Amount</th>
+                <th>Hash</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </section>
 
       <section id="contacts" class="page">

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -222,6 +222,15 @@ th {
   padding: 6px 10px;
 }
 
+.network-history {
+  margin-top: 20px;
+}
+
+.network-history button {
+  margin-bottom: 10px;
+  padding: 6px 10px;
+}
+
 .rpc-settings {
   margin: 20px 0;
 }


### PR DESCRIPTION
## Summary
- add network account history section to wallet page
- retrieve transaction history from the configured RPC endpoint
- style new section and update README with info on fetching history

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd linux-desktop && npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688ac393a59c832f8319b9db4afbadd8