### PR TITLE
Add seed import/export to desktop wallet

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -31,6 +31,10 @@ The settings page also lets you configure the RPC endpoint used for network
 requests. By default the application targets `https://rpc.nyano.org` but you
 can update the URL to point to any compatible node.
 
+You can also export your wallet seed to a text file or import it from one using
+the new **Export** and **Import** buttons in the Wallet Seed section. This makes
+backing up and restoring your wallet straightforward.
+
 ## Install dependencies
 
 ```

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -138,6 +138,9 @@
           </button>
           <button id="generate-seed">Generate</button>
           <button id="save-seed">Save</button>
+          <button id="export-seed">Export</button>
+          <button id="import-seed">Import</button>
+          <input type="file" id="seed-file" accept="text/plain" hidden />
         </div>
         <div class="network-settings">
           <h3>Network</h3>

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -53,6 +53,9 @@ window.addEventListener('DOMContentLoaded', () => {
   const toggleSeedBtn = document.getElementById('toggle-seed');
   const generateSeedBtn = document.getElementById('generate-seed');
   const saveSeedBtn = document.getElementById('save-seed');
+  const exportSeedBtn = document.getElementById('export-seed');
+  const importSeedBtn = document.getElementById('import-seed');
+  const seedFileInput = document.getElementById('seed-file');
   const networkSelect = document.getElementById('network-select');
   const rpcInput = document.getElementById('rpc-url');
   const saveRpcBtn = document.getElementById('save-rpc');
@@ -101,6 +104,43 @@ window.addEventListener('DOMContentLoaded', () => {
     saveSeedBtn.addEventListener('click', () => {
       localStorage.setItem('seed', seedInput.value.trim());
       updateAddress();
+    });
+  }
+
+  const exportSeed = () => {
+    if (!seedInput) return;
+    const seed = seedInput.value.trim();
+    if (!seed) return;
+    const blob = new Blob([seed], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nyano-seed.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importSeed = files => {
+    const file = files[0];
+    if (!file || !seedInput) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      seedInput.value = (reader.result || '').trim();
+      localStorage.setItem('seed', seedInput.value);
+      updateAddress();
+    };
+    reader.readAsText(file);
+  };
+
+  if (exportSeedBtn) {
+    exportSeedBtn.addEventListener('click', exportSeed);
+  }
+
+  if (importSeedBtn && seedFileInput) {
+    importSeedBtn.addEventListener('click', () => seedFileInput.click());
+    seedFileInput.addEventListener('change', e => {
+      importSeed(e.target.files);
+      seedFileInput.value = '';
     });
   }
 


### PR DESCRIPTION
## Summary
- allow exporting and importing the wallet seed
- document the new feature

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `linux-desktop` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ac4ed8ea8832f939bcc0f8b0ca582