### PR TITLE
Enhance desktop UI with persistent window state

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ where addresses can be added, edited or removed. Contacts support import and exp
 to a JSON file for easy backup.
 You can also export or import the entire application settings from the Settings
 page or reset all saved data.
+The desktop app now saves its window size and position so it reopens exactly
+where you left it. A basic application menu provides Quit and About actions; the
+About dialog shows the current version number.
 
 ```
 cd linux-desktop

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -40,6 +40,12 @@ options. These let you back up or restore all application data including your
 seed, contacts, history and preferences. A **Reset** button is available to
 clear all saved data if needed.
 
+Window size and position are now remembered across sessions. The app creates a
+small `window-state.json` file under Electron's userData directory and restores
+the previous bounds on startup. An application menu with **File** and **Help**
+items has also been added. Selecting **About** from the Help menu shows a simple
+dialog displaying the application version.
+
 ## Install dependencies
 
 ```

--- a/linux-desktop/main.js
+++ b/linux-desktop/main.js
@@ -1,20 +1,82 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, Menu, dialog } = require('electron');
 const path = require('path');
+const fs = require('fs');
+const { name, version } = require('./package.json');
+
+function getStatePath() {
+  return path.join(app.getPath('userData'), 'window-state.json');
+}
+
+function loadWindowState() {
+  try {
+    return JSON.parse(fs.readFileSync(getStatePath(), 'utf-8'));
+  } catch {
+    return { width: 900, height: 700 };
+  }
+}
+
+function saveWindowState(win) {
+  const bounds = win.getBounds();
+  const state = {
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+    isMaximized: win.isMaximized()
+  };
+  try {
+    fs.writeFileSync(getStatePath(), JSON.stringify(state));
+  } catch {}
+}
 
 function createWindow () {
+  const state = loadWindowState();
   const win = new BrowserWindow({
-    width: 900,
-    height: 700,
+    width: state.width || 900,
+    height: state.height || 700,
+    x: state.x,
+    y: state.y,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }
   });
 
+  if (state.isMaximized) win.maximize();
+
   win.loadFile('index.html');
+
+  win.on('close', () => saveWindowState(win));
+}
+
+function createMenu() {
+  const template = [
+    {
+      label: 'File',
+      submenu: [{ role: 'quit' }]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'About',
+          click: () => {
+            dialog.showMessageBox({
+              type: 'info',
+              message: `${name} ${version}`,
+              buttons: ['OK']
+            });
+          }
+        }
+      ]
+    }
+  ];
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
 }
 
 app.whenReady().then(() => {
   createWindow();
+  createMenu();
 
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();


### PR DESCRIPTION
## Summary
- remember window size and position across launches
- add basic app menu with Quit and About
- document new behaviour in desktop README
- mention new features in top-level README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688acc5f8630832f95a1a411431cb001