### PR TITLE
Enhance desktop dashboard with network stats

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -3,7 +3,9 @@
 This directory contains a small Electron application that acts as the starting
 point for a Nyano desktop wallet and miner. The interface uses a left side
 navigation bar with separate pages for **Wallet**, **Dashboard**, **Miner**, and
-**Settings**. The Dashboard fetches the current Nano price and basic network status. The platform information and application version are exposed via a
+**Settings**. The Dashboard fetches the current Nano price and now also displays
+block and peer counts pulled from the configured RPC node. The platform
+information and application version are exposed via a
 preload API and shown on the settings page. The wallet view includes a simple
 send form and address display, while the miner page provides start/stop controls.
 A dark mode toggle is also available in the settings. Sent transactions are

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -112,6 +112,8 @@
         <h2>Dashboard</h2>
         <div class="price">NANO Price: <span id="nano-price">loading...</span> USD</div>
         <div class="network">Network Status: <span id="network-status">checking...</span></div>
+        <div class="block-count">Blocks: <span id="block-count">-</span></div>
+        <div class="peer-count">Peers: <span id="peer-count">-</span></div>
         <button id="refresh-dashboard">Refresh</button>
       </section>
 


### PR DESCRIPTION
## Summary
- show block and peer counts on the dashboard
- fetch new metrics from RPC
- document new dashboard info

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix linux-desktop test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688acfdb8c9c832f908c77fdc62f2780