### PR TITLE
Add NyanoScan explorer links

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -53,6 +53,10 @@ the previous bounds on startup. An application menu with **File** and **Help**
 items has also been added. Selecting **About** from the Help menu shows a simple
 dialog displaying the application version.
 
+Account addresses and history entries include quick links to the NyanoScan
+block explorer. Click the external link icon next to your address or any hash in
+the history table to view details in your default browser.
+
 ## Install dependencies
 
 ```

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -47,6 +47,7 @@
           <label>Address (index: <span id="current-index">0</span>)</label>
           <input type="text" id="address" readonly />
           <button id="copy-address" title="Copy"><i class="fas fa-copy"></i></button>
+          <button id="view-address" title="Open in explorer"><i class="fas fa-external-link-alt"></i></button>
         </div>
         <canvas id="address-qr" width="128" height="128"></canvas>
 

--- a/linux-desktop/preload.js
+++ b/linux-desktop/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge } = require('electron');
+const { contextBridge, shell } = require('electron');
 const { version } = require('./package.json');
 const {
   generateSeed,
@@ -20,5 +20,6 @@ contextBridge.exposeInMainWorld('nyano', {
   derivePublicKey,
   createBlock,
   convert,
-  Unit
+  Unit,
+  openExternal: url => shell.openExternal(url)
 });

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -303,6 +303,7 @@ window.addEventListener('DOMContentLoaded', () => {
   else fetchBalance();
 
   const copyBtn = document.getElementById('copy-address');
+  const viewAddrBtn = document.getElementById('view-address');
   const refreshBalanceBtn = document.getElementById('refresh-balance');
   if (copyBtn) {
     copyBtn.addEventListener('click', () => {
@@ -311,6 +312,14 @@ window.addEventListener('DOMContentLoaded', () => {
         copyBtn.textContent = 'Copied!';
         setTimeout(() => (copyBtn.textContent = ''), 1000);
       });
+    });
+  }
+  if (viewAddrBtn) {
+    viewAddrBtn.addEventListener('click', () => {
+      updateAddress();
+      window.nyano.openExternal(
+        `https://nyanoscan.org/account/${address}`
+      );
     });
   }
   if (refreshBalanceBtn) {
@@ -493,8 +502,15 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     entries.forEach(e => {
       const row = document.createElement('tr');
-      row.innerHTML = `<td>${e.type}</td><td>${e.amount}</td><td>${e.hash}</td>`;
+      row.innerHTML = `<td>${e.type}</td><td>${e.amount}</td><td><a href="#" data-hash="${e.hash}">${e.hash}</a></td>`;
       tbody.appendChild(row);
+    });
+    tbody.querySelectorAll('a[data-hash]').forEach(link => {
+      link.addEventListener('click', ev => {
+        ev.preventDefault();
+        const h = link.getAttribute('data-hash');
+        window.nyano.openExternal(`https://nyanoscan.org/block/${h}`);
+      });
     });
   };
 

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -123,8 +123,13 @@ header h1 {
 }
 
 .wallet-address input {
-  width: calc(100% - 70px);
+  width: calc(100% - 110px);
   padding: 6px;
+  margin-right: 4px;
+}
+
+.wallet-address button {
+  padding: 6px 10px;
   margin-right: 4px;
 }
 
@@ -229,6 +234,12 @@ th {
 .network-history button {
   margin-bottom: 10px;
   padding: 6px 10px;
+}
+
+.network-history a {
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .rpc-settings {


### PR DESCRIPTION
## Summary
- add `openExternal` helper in preload
- link wallet address and account history to NyanoScan
- include new button for explorer access
- refine wallet CSS
- document new explorer features

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688adfe56504832fb1231a7b5becdf62