### PR TITLE
Add active network indicator to desktop wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can also export or import the entire application settings from the Settings
 page or reset all saved data. Transactions created in the wallet view are now
 broadcast to the configured RPC endpoint, so the wallet is usable on the Nyano
 network.
+The wallet page now also shows the currently selected network so you can easily
+confirm whether you are on mainnet, testnet or beta.
 The desktop app now saves its window size and position so it reopens exactly
 where you left it. A basic application menu provides Quit and About actions; the
 About dialog shows the current version number.

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -15,7 +15,8 @@ tracked locally and shown in a simple history table within the wallet view.
 Recent updates introduce basic wallet management. You can generate or import a
 seed on the **Settings** page and select which network (mainnet, testnet, or
 beta) the app should target. The derived Nyano address is displayed in the
-wallet view along with a QR code.
+wallet view along with a QR code. The currently selected network is also shown
+on the wallet page so you always know which environment is active.
 
 You can now manage saved addresses on the **Contacts** page. Stored contacts
 let you quickly fill the send form in the wallet view and are persisted in the

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -51,6 +51,8 @@
         </div>
         <canvas id="address-qr" width="128" height="128"></canvas>
 
+        <div class="current-network">Network: <span id="current-network">mainnet</span></div>
+
         <div class="send-form">
           <h3>Send</h3>
           <label>To <input type="text" id="send-to" placeholder="Nyano address" /></label>

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -69,6 +69,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const setPasswordBtn = document.getElementById('set-password');
   const unlockWalletBtn = document.getElementById('unlock-wallet');
   const networkSelect = document.getElementById('network-select');
+  const currentNetworkEl = document.getElementById('current-network');
   const rpcInput = document.getElementById('rpc-url');
   const saveRpcBtn = document.getElementById('save-rpc');
   const indexInput = document.getElementById('account-index');
@@ -87,6 +88,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   const storedNetwork = localStorage.getItem('network') || 'mainnet';
   if (networkSelect) networkSelect.value = storedNetwork;
+  if (currentNetworkEl) currentNetworkEl.textContent = storedNetwork;
   const storedRpc = localStorage.getItem('rpcUrl') || 'https://rpc.nyano.org';
   if (rpcInput) rpcInput.value = storedRpc;
   const storedIndex = parseInt(localStorage.getItem('accountIndex') || '0', 10);
@@ -306,6 +308,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (networkSelect) {
     networkSelect.addEventListener('change', () => {
       localStorage.setItem('network', networkSelect.value);
+      if (currentNetworkEl) currentNetworkEl.textContent = networkSelect.value;
     });
   }
 

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -225,6 +225,11 @@ th {
   padding: 2px 6px;
 }
 
+.current-network {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 .add-contact {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- display current network in wallet view
- update renderer to keep the network label in sync with settings
- tweak styles for new network section
- document the network indicator in README files

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_688ae3eb7340832fa700d460d0d47078