### PR TITLE
Add nano reference address and nyano balance

### DIFF
--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -51,6 +51,13 @@
             <i class="fas fa-external-link-alt"></i>
           </button>
         </div>
+        <div class="nano-address">
+          <label>NANO Reference</label>
+          <input type="text" id="nano-address" readonly />
+          <button id="copy-nano-address" title="Copy">
+            <i class="fas fa-copy"></i>
+          </button>
+        </div>
         <canvas id="address-qr" width="192" height="192"></canvas>
         <button id="save-address-qr" title="Save QR">
           <i class="fas fa-download"></i>

--- a/linux-desktop/preload.js
+++ b/linux-desktop/preload.js
@@ -17,6 +17,8 @@ contextBridge.exposeInMainWorld('nyano', {
   generateSeed,
   deriveAddress: (seed, index = 0) =>
     deriveAddress(seed, index, { prefix: 'nyano_' }),
+  deriveNanoAddress: (seed, index = 0) =>
+    deriveAddress(seed, index, { prefix: 'nano_' }),
   deriveSecretKey,
   derivePublicKey,
   createBlock,

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -125,8 +125,11 @@ window.addEventListener('DOMContentLoaded', () => {
     const seed = seedInput.value.trim();
     if (!seed) return;
     const addr = window.nyano.deriveAddress(seed, accountIndex);
+    const nanoAddr = window.nyano.deriveNanoAddress(seed, accountIndex);
     address = addr;
+    nanoAddress = nanoAddr;
     if (addressEl) addressEl.value = addr;
+    if (nanoAddressEl) nanoAddressEl.value = nanoAddr;
     if (currentIndexEl) currentIndexEl.textContent = accountIndex;
     if (qrCanvas && typeof QRCode !== 'undefined') {
       QRCode.toCanvas(qrCanvas, addr, { margin: 1 }, () => {});
@@ -369,7 +372,7 @@ window.addEventListener('DOMContentLoaded', () => {
       if (data && data.balance) {
         const nyano = window.nyano.convert(data.balance, {
           from: window.nyano.Unit.raw,
-          to: window.nyano.Unit.NANO,
+          to: window.nyano.Unit.nano,
         });
         balanceEl.textContent = nyano;
       } else {
@@ -384,11 +387,18 @@ window.addEventListener('DOMContentLoaded', () => {
   let address = storedSeed
     ? window.nyano.deriveAddress(storedSeed, accountIndex)
     : 'nyano_11111111111111111111111111111111111111111111111111111111111';
+  let nanoAddress = storedSeed
+    ? window.nyano.deriveNanoAddress(storedSeed, accountIndex)
+    : 'nano_11111111111111111111111111111111111111111111111111111111111';
   const balanceEl = document.getElementById('balance');
   const addressEl = document.getElementById('address');
+  const nanoAddressEl = document.getElementById('nano-address');
   const qrCanvas = document.getElementById('address-qr');
   if (addressEl) {
     addressEl.value = address;
+  }
+  if (nanoAddressEl) {
+    nanoAddressEl.value = nanoAddress;
   }
   if (balanceEl) {
     balanceEl.textContent = '0';
@@ -400,6 +410,7 @@ window.addEventListener('DOMContentLoaded', () => {
   else if (!encryptedSeed) fetchBalance();
 
   const copyBtn = document.getElementById('copy-address');
+  const copyNanoBtn = document.getElementById('copy-nano-address');
   const viewAddrBtn = document.getElementById('view-address');
   const refreshBalanceBtn = document.getElementById('refresh-balance');
   const saveQrBtn = document.getElementById('save-address-qr');
@@ -410,6 +421,16 @@ window.addEventListener('DOMContentLoaded', () => {
       navigator.clipboard.writeText(address).then(() => {
         copyBtn.textContent = 'Copied!';
         setTimeout(() => (copyBtn.textContent = ''), 1000);
+      });
+    });
+  }
+  if (copyNanoBtn) {
+    copyNanoBtn.addEventListener('click', () => {
+      updateAddress();
+      const nanoAddr = nanoAddressEl ? nanoAddressEl.value : '';
+      navigator.clipboard.writeText(nanoAddr).then(() => {
+        copyNanoBtn.textContent = 'Copied!';
+        setTimeout(() => (copyNanoBtn.textContent = ''), 1000);
       });
     });
   }

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -132,6 +132,21 @@ header h1 {
   margin-right: 4px;
 }
 
+.nano-address {
+  margin-bottom: 20px;
+}
+
+.nano-address input {
+  width: calc(100% - 110px);
+  padding: 6px;
+  margin-right: 4px;
+}
+
+.nano-address button {
+  padding: 6px 10px;
+  margin-right: 4px;
+}
+
 .send-form label {
   display: block;
   margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- display a reference NANO address alongside the nyano address
- expose a `deriveNanoAddress` helper in preload
- show balances in nyano units (10^-6 XNO)
- support copying the reference NANO address

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688af25d88d8832fb2038992a26e4fe3