### PR TITLE
Implement automatic nano node launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,7 @@ Start the node with:
 ./nano-node/build/nano_node --daemon
 ```
 
-Set the RPC endpoint in the desktop wallet settings to `http://localhost:7076` to
-interact with your local node.
+Once the node is built, launching the desktop wallet will also automatically
+start the daemon if the binary is found in `nano-node/build` and shut it down
+when you exit the wallet. Set the RPC endpoint in the desktop wallet settings to
+`http://localhost:7076` to interact with your local node.


### PR DESCRIPTION
## Summary
- automatically spawn `nano_node` when launching the desktop wallet and stop it on exit
- document the new behaviour in the local node section

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint "**/*.js"` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_688b04502ae0832f92ac82f47b058baa