### PR TITLE
Improve nano node integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If you are interested in including a link on nyano.org, please list it here firs
 
 ## installation
 npm install
+You can build a packaged desktop wallet and local node by running
+`./install.sh` on Linux systems.
 ## Desktop wallet
 See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.
 The app now includes seed management, network selection on the settings page and a contacts view
@@ -57,7 +59,9 @@ npm start
 ```
 
 If a `nano_node` binary exists under `nano-node/build`, the desktop app
-will automatically launch it in daemon mode when started.
+will automatically launch it in daemon mode when started. When the
+binary is missing, the app tries to build it by running
+`scripts/setup-nano-node.sh`.
 
 ## Running a local Nano node
 You can build and run your own Nano node for use with the desktop wallet.

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,9 @@ cd "$APP_DIR"
 # install dependencies
 npm install
 
+# build nano node if missing
+"$SCRIPT_DIR/scripts/setup-nano-node.sh"
+
 # build packaged application
 npm run build
 

--- a/linux-desktop/main.js
+++ b/linux-desktop/main.js
@@ -1,7 +1,7 @@
 const { app, BrowserWindow, Menu, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const { name, version } = require('./package.json');
 
 function getStatePath() {
@@ -33,6 +33,16 @@ function saveWindowState(win) {
 let nodeProcess;
 function startLocalNode() {
   const nodePath = path.join(__dirname, '..', 'nano-node', 'build', 'nano_node');
+  if (!fs.existsSync(nodePath)) {
+    const setupScript = path.join(__dirname, '..', 'scripts', 'setup-nano-node.sh');
+    if (fs.existsSync(setupScript)) {
+      try {
+        spawnSync(setupScript, { stdio: 'inherit' });
+      } catch (err) {
+        console.error('Failed to build nano_node', err);
+      }
+    }
+  }
   if (fs.existsSync(nodePath)) {
     nodeProcess = spawn(nodePath, ['--daemon']);
     nodeProcess.on('error', err => {


### PR DESCRIPTION
## Summary
- auto-build local nano node if missing when starting desktop app
- call setup script from install.sh
- document new behaviour in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_688b0629b070832f831fa449b05bbbbd