### PR TITLE
Add local nano node controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ npm start
 ```
 
 If a `nano_node` binary exists under `nano-node/build`, the desktop app
-will automatically launch it in daemon mode when started.
+will automatically launch it in daemon mode when started. You can also
+start or stop the embedded node from the **Settings** page using the new
+controls.
 
 ## Running a local Nano node
 You can build and run your own Nano node for use with the desktop wallet.

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -212,6 +212,12 @@
           <input type="text" id="rpc-url" placeholder="https://rpc.nyano.org" />
           <button id="save-rpc">Save</button>
         </div>
+        <div class="node-settings">
+          <h3>Local Node</h3>
+          <span id="node-status">unknown</span>
+          <button id="start-node">Start Node</button>
+          <button id="stop-node">Stop Node</button>
+        </div>
         <div class="app-settings">
           <h3>App Data</h3>
           <button id="export-settings">Export Settings</button>

--- a/linux-desktop/preload.js
+++ b/linux-desktop/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, shell } = require('electron');
+const { contextBridge, shell, ipcRenderer } = require('electron');
 const { version } = require('./package.json');
 const crypto = require('crypto');
 const {
@@ -8,7 +8,7 @@ const {
   derivePublicKey,
   createBlock,
   convert,
-  Unit
+  Unit,
 } = require('nanocurrency');
 
 contextBridge.exposeInMainWorld('nyano', {
@@ -24,7 +24,7 @@ contextBridge.exposeInMainWorld('nyano', {
   createBlock,
   convert,
   Unit,
-  openExternal: url => shell.openExternal(url),
+  openExternal: (url) => shell.openExternal(url),
   encryptSeed: (seed, password) => {
     const iv = crypto.randomBytes(16);
     const key = crypto.createHash('sha256').update(password).digest();
@@ -44,5 +44,8 @@ contextBridge.exposeInMainWorld('nyano', {
     } catch {
       return null;
     }
-  }
+  },
+  startNode: () => ipcRenderer.invoke('start-node'),
+  stopNode: () => ipcRenderer.invoke('stop-node'),
+  nodeStatus: () => ipcRenderer.invoke('node-status'),
 });

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -103,6 +103,33 @@ window.addEventListener('DOMContentLoaded', () => {
   const importSettingsBtn = document.getElementById('import-settings');
   const resetSettingsBtn = document.getElementById('reset-settings');
   const settingsFileInput = document.getElementById('settings-file');
+  const startNodeBtn = document.getElementById('start-node');
+  const stopNodeBtn = document.getElementById('stop-node');
+  const nodeStatusEl = document.getElementById('node-status');
+
+  const updateNodeControls = async () => {
+    const running = await window.nyano.nodeStatus();
+    if (nodeStatusEl)
+      nodeStatusEl.textContent = running ? 'running' : 'stopped';
+    if (startNodeBtn) startNodeBtn.disabled = running;
+    if (stopNodeBtn) stopNodeBtn.disabled = !running;
+  };
+
+  if (startNodeBtn) {
+    startNodeBtn.addEventListener('click', async () => {
+      await window.nyano.startNode();
+      updateNodeControls();
+    });
+  }
+
+  if (stopNodeBtn) {
+    stopNodeBtn.addEventListener('click', async () => {
+      await window.nyano.stopNode();
+      updateNodeControls();
+    });
+  }
+
+  updateNodeControls();
 
   const encryptedSeed = localStorage.getItem('encryptedSeed');
   const storedSeed = encryptedSeed ? '' : localStorage.getItem('seed') || '';

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -298,6 +298,15 @@ th {
   padding: 6px 10px;
 }
 
+.node-settings {
+  margin: 20px 0;
+}
+
+.node-settings button {
+  padding: 6px 10px;
+  margin-right: 4px;
+}
+
 .app-settings {
   margin: 20px 0;
 }


### PR DESCRIPTION
## Summary
- auto-start local nano node still and allow start/stop from the Settings page
- expose node control APIs via preload and main process IPC
- update desktop HTML/CSS for node status controls
- document ability to control the embedded node in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b0629b070832f831fa449b05bbbbd