### PR TITLE
Fix lint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-n": "^17.21.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
- add missing `eslint-plugin-n` dependency for ESLint

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b75be1c50832faef125786d54c792