### PR TITLE
Add auto-start toggle for embedded node

### DIFF
--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -41,6 +41,11 @@ The settings page also lets you configure the RPC endpoint used for network
 requests. By default the application targets `https://rpc.nyano.org` but you
 can update the URL to point to any compatible node.
 
+You can run a local node directly from the app. The **Local Node** section
+includes Start and Stop buttons along with a new **Auto-start on launch**
+option. When enabled the embedded node daemon will automatically start when the
+application launches.
+
 You can also export your wallet seed to a text file or import it from one using
 the new **Export** and **Import** buttons in the Wallet Seed section. This makes
 backing up and restoring your wallet straightforward.

--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -217,6 +217,9 @@
           <span id="node-status">unknown</span>
           <button id="start-node">Start Node</button>
           <button id="stop-node">Stop Node</button>
+          <label class="toggle">
+            <input type="checkbox" id="auto-start-node" /> Auto-start on launch
+          </label>
         </div>
         <div class="app-settings">
           <h3>App Data</h3>


### PR DESCRIPTION
## Summary
- add auto-start option in Settings for running the local node
- start node automatically if enabled and persist preference
- export/import auto-start setting with other app data
- update README with instructions for new feature

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b79b05ed8832fa604e08f76513c36