### PR TITLE
Fix auto-start behavior for embedded node

### DIFF
--- a/linux-desktop/main.js
+++ b/linux-desktop/main.js
@@ -116,7 +116,6 @@ ipcMain.handle('stop-node', () => {
 ipcMain.handle('node-status', () => isNodeRunning());
 
 app.whenReady().then(() => {
-  startLocalNode();
   createWindow();
   createMenu();
 


### PR DESCRIPTION
## Summary
- remove automatic node startup from the Electron main process so the app now respects the `Auto-start on launch` toggle

## Testing
- `npm run lint`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688b7b1ccca4832f847fc467d1a65094