### PR TITLE
Add helper script to update local nano node

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ or simply run the convenience script:
 
 Set the RPC endpoint in the desktop wallet settings to `http://localhost:7076` to
 interact with your local node.
+
+## Updating the local node
+If the `nano-node` source was built previously, you can update to the latest
+version and rebuild the binary using the helper script:
+
+```bash
+./scripts/update-nano-node.sh
+```
+
+The script fetches the newest changes from the `nano-node` repository and
+recompiles the daemon in `nano-node/build`.

--- a/scripts/update-nano-node.sh
+++ b/scripts/update-nano-node.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+DIR="nano-node"
+REPO="https://github.com/djlacavera21/nano-node.git"
+
+if [ ! -d "$DIR" ]; then
+  echo "Node source not found. Run scripts/setup-nano-node.sh first." >&2
+  exit 1
+fi
+
+cd "$DIR"
+
+git fetch origin
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Local changes detected in $DIR. Please commit or stash them first." >&2
+  exit 1
+fi
+
+git pull --ff-only origin master
+
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+
+echo "Nano node updated in $(pwd)."


### PR DESCRIPTION
## Summary
- add `scripts/update-nano-node.sh` to fetch and rebuild the node
- document how to update the local node in README

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b7c745538832f842edaa190246386