### PR TITLE
Add service worker for offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If you are interested in including a link on nyano.org, please list it here firs
 
 ## installation
 npm install
+
+## Offline access
+The site registers a small service worker (`sw.js`) to cache static assets so
+that pages remain available when offline. Load the homepage once and it will
+work without a network connection. The service worker can be removed via your
+browser settings if needed.
 ## Desktop wallet
 See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.
 The app now includes seed management, network selection on the settings page and a contacts view

--- a/index.html
+++ b/index.html
@@ -87,6 +87,13 @@
       defer
       src="node_modules/@fortawesome/fontawesome-free/js/all.min.js"
     ></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
     <!-- Cloudflare Web Analytics -->
     <script
       defer

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,31 @@
+const CACHE_NAME = 'nyano-site-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/css/styles.css',
+  '/img/nyano2.png',
+  '/favicon-32x32.png',
+  '/favicon-16x16.png',
+  '/android-chrome-72x72.png',
+  '/apple-touch-icon.png',
+  '/safari-pinned-tab.svg',
+];
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
+      )
+    )
+  );
+});
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((res) => res || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add a simple service worker to cache static assets
- register the service worker in `index.html`
- document offline capability in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688b7e13d3ac832f903dade91c302956