### PR TITLE
Enhance offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 ## Offline access
 The site registers a small service worker (`sw.js`) to cache static assets so
 that pages remain available when offline. Load the homepage once and it will
-work without a network connection. The service worker can be removed via your
+work without a network connection. When offline, requests will show a lightweight offline page if the resource is unavailable. The service worker can be removed via your
 browser settings if needed.
 ## Desktop wallet
 See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline - nyano.org</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <div id="holding" class="uk-section">
+      <h2 class="nyano">nyano</h2>
+      <p>You appear to be offline. Some functionality may be unavailable.</p>
+      <p><a href="/">Return to the homepage</a></p>
+    </div>
+  </body>
+</html>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,14 +1,15 @@
 {
-    "name": "",
-    "short_name": "",
-    "icons": [
-        {
-            "src": "/android-chrome-72x72.png",
-            "sizes": "72x72",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
-    "display": "standalone"
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "start_url": "/"
 }

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,9 @@
-const CACHE_NAME = 'nyano-site-v1';
+const CACHE_NAME = 'nyano-site-v2';
+const OFFLINE_URL = '/offline.html';
 const ASSETS = [
   '/',
   '/index.html',
+  OFFLINE_URL,
   '/css/styles.css',
   '/img/nyano2.png',
   '/favicon-32x32.png',
@@ -26,6 +28,14 @@ self.addEventListener('activate', (event) => {
 });
 self.addEventListener('fetch', (event) => {
   event.respondWith(
-    caches.match(event.request).then((res) => res || fetch(event.request))
+    fetch(event.request)
+      .then((response) => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() =>
+        caches.match(event.request).then((res) => res || caches.match(OFFLINE_URL))
+      )
   );
 });


### PR DESCRIPTION
## Summary
- add `offline.html` fallback page
- improve service worker to cache offline assets and show fallback when needed
- set `start_url` in web manifest
- mention new offline behavior in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b7f809360832f9d75e2b0ffa59e46