### PR TITLE
Add cross-platform packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ npm install
 npm start
 ```
 
+To generate packages for major platforms run:
+
+```bash
+npm run build-all
+```
+
 If a `nano_node` binary exists under `nano-node/build`, the desktop app
 will automatically launch it in daemon mode when started. You can also
 start or stop the embedded node from the **Settings** page using the new

--- a/linux-desktop/README.md
+++ b/linux-desktop/README.md
@@ -90,4 +90,10 @@ npm start
 npm run build
 ```
 
+### Build packages for all platforms
+
+```
+npm run build-all
+```
+
 This is a starting point. Future work can integrate wallet functionality, mining controls, and additional features inspired by platforms like Kraken. The interface uses Font Awesome icons bundled via `npm`.

--- a/linux-desktop/package.json
+++ b/linux-desktop/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . NyanoDesktop --overwrite"
+    "build": "electron-packager . NyanoDesktop --overwrite",
+    "build-all": "electron-packager . NyanoDesktop --overwrite --platform=linux,win32,darwin --arch=x64 --out=dist"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.0.0",


### PR DESCRIPTION
## Summary
- document generating builds for all platforms in the desktop wallet
- add `build-all` script in `linux-desktop/package.json`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b820cf2a8832faff534c3a38e59c3