### PR TITLE
Add Nano price widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
           supported wallets as well as exchanges allowing you to swap it from
           your local traditional currency.
         </p>
+        <p>Current Nano price: <span id="nano-price">-</span> USD</p>
       </div>
     </div>
 
@@ -87,6 +88,7 @@
       defer
       src="node_modules/@fortawesome/fontawesome-free/js/all.min.js"
     ></script>
+    <script defer src="js/price.js"></script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {

--- a/js/price.js
+++ b/js/price.js
@@ -1,0 +1,20 @@
+async function fetchPrice() {
+  const priceEl = document.getElementById('nano-price');
+  if (!priceEl) return;
+  try {
+    priceEl.textContent = 'loading...';
+    const resp = await fetch(
+      'https://api.coingecko.com/api/v3/simple/price?ids=nano&vs_currencies=usd',
+    );
+    if (!resp.ok) throw new Error('network');
+    const data = await resp.json();
+    priceEl.textContent = data.nano.usd.toFixed(2);
+  } catch (err) {
+    priceEl.textContent = 'n/a';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchPrice();
+  setInterval(fetchPrice, 60000);
+});

--- a/sw.js
+++ b/sw.js
@@ -11,19 +11,22 @@ const ASSETS = [
   '/android-chrome-72x72.png',
   '/apple-touch-icon.png',
   '/safari-pinned-tab.svg',
+  '/js/price.js',
 ];
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
   );
 });
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
-      )
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+        ),
+      ),
   );
 });
 self.addEventListener('fetch', (event) => {
@@ -31,11 +34,15 @@ self.addEventListener('fetch', (event) => {
     fetch(event.request)
       .then((response) => {
         const clone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        caches
+          .open(CACHE_NAME)
+          .then((cache) => cache.put(event.request, clone));
         return response;
       })
       .catch(() =>
-        caches.match(event.request).then((res) => res || caches.match(OFFLINE_URL))
-      )
+        caches
+          .match(event.request)
+          .then((res) => res || caches.match(OFFLINE_URL)),
+      ),
   );
 });


### PR DESCRIPTION
## Summary
- show the current Nano price on the homepage
- fetch price periodically from CoinGecko
- cache the new script via the service worker

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b8637b020832f8288a08e8f6437e5