### PR TITLE
Improve PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,26 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.register('/sw.js').then((reg) => {
+            if (reg.waiting) {
+              reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+              window.location.reload();
+            }
+            reg.addEventListener('updatefound', () => {
+              const newWorker = reg.installing;
+              if (newWorker) {
+                newWorker.addEventListener('statechange', () => {
+                  if (
+                    newWorker.state === 'installed' &&
+                    navigator.serviceWorker.controller
+                  ) {
+                    newWorker.postMessage({ type: 'SKIP_WAITING' });
+                    window.location.reload();
+                  }
+                });
+              }
+            });
+          });
         });
       }
     </script>

--- a/offline.html
+++ b/offline.html
@@ -10,6 +10,7 @@
     <div id="holding" class="uk-section">
       <h2 class="nyano">nyano</h2>
       <p>You appear to be offline. Some functionality may be unavailable.</p>
+      <p>Please check your internet connection and try again.</p>
       <p><a href="/">Return to the homepage</a></p>
     </div>
   </body>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,6 +1,7 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "Nyano",
+  "short_name": "Nyano",
+  "description": "Nyano - The secret meme coin inside Nano",
   "icons": [
     {
       "src": "/android-chrome-72x72.png",

--- a/sw.js
+++ b/sw.js
@@ -12,6 +12,7 @@ const ASSETS = [
   '/apple-touch-icon.png',
   '/safari-pinned-tab.svg',
   '/js/price.js',
+  '/css/Ubuntu-Title.woff2',
 ];
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -28,6 +29,9 @@ self.addEventListener('activate', (event) => {
         ),
       ),
   );
+});
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
 });
 self.addEventListener('fetch', (event) => {
   event.respondWith(


### PR DESCRIPTION
## Summary
- cache local font in service worker
- add service worker update logic
- enhance offline page messaging
- fill out PWA manifest

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_688b88c5c8a4832fb4099446503b2261