### PR TITLE
Enhance price fetcher with local cache

### DIFF
--- a/js/price.js
+++ b/js/price.js
@@ -1,3 +1,8 @@
+function updatePrice(value) {
+  const priceEl = document.getElementById('nano-price');
+  if (priceEl) priceEl.textContent = value;
+}
+
 async function fetchPrice() {
   const priceEl = document.getElementById('nano-price');
   if (!priceEl) return;
@@ -8,13 +13,22 @@ async function fetchPrice() {
     );
     if (!resp.ok) throw new Error('network');
     const data = await resp.json();
-    priceEl.textContent = data.nano.usd.toFixed(2);
+    const price = data.nano.usd.toFixed(2);
+    updatePrice(price);
+    localStorage.setItem('nano-price', price);
   } catch (err) {
-    priceEl.textContent = 'n/a';
+    const cached = localStorage.getItem('nano-price');
+    if (cached) {
+      updatePrice(`${cached} (cached)`);
+    } else {
+      updatePrice('n/a');
+    }
   }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const cached = localStorage.getItem('nano-price');
+  if (cached) updatePrice(cached);
   fetchPrice();
   setInterval(fetchPrice, 60000);
 });


### PR DESCRIPTION
## Summary
- fetch Nano price from Coingecko
- cache last successful price in localStorage to display when offline

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b8b21c20c832f92e8dca28e436d76