### PR TITLE
Enhance site with live network status

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
           your local traditional currency.
         </p>
         <p>Current Nano price: <span id="nano-price">-</span> USD</p>
+        <p>
+          Network status: <span id="network-status">-</span>, Blocks:
+          <span id="block-count">-</span>
+        </p>
       </div>
     </div>
 
@@ -89,6 +93,7 @@
       src="node_modules/@fortawesome/fontawesome-free/js/all.min.js"
     ></script>
     <script defer src="js/price.js"></script>
+    <script defer src="js/network.js"></script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {

--- a/js/network.js
+++ b/js/network.js
@@ -1,0 +1,26 @@
+async function updateNetworkStatus() {
+  const statusEl = document.getElementById('network-status');
+  const blockEl = document.getElementById('block-count');
+  if (!statusEl || !blockEl) return;
+  try {
+    statusEl.textContent = 'checking...';
+    blockEl.textContent = '...';
+    const resp = await fetch('https://rpc.nyano.org', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'block_count' }),
+    });
+    if (!resp.ok) throw new Error('network');
+    const data = await resp.json();
+    statusEl.textContent = 'online';
+    blockEl.textContent = data.count;
+  } catch (err) {
+    statusEl.textContent = 'offline';
+    blockEl.textContent = '-';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateNetworkStatus();
+  setInterval(updateNetworkStatus, 60000);
+});

--- a/sw.js
+++ b/sw.js
@@ -12,6 +12,7 @@ const ASSETS = [
   '/apple-touch-icon.png',
   '/safari-pinned-tab.svg',
   '/js/price.js',
+  '/js/network.js',
   '/css/Ubuntu-Title.woff2',
 ];
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- add small script to check RPC block count
- display network status and block count on homepage
- cache the new script via service worker

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b8da0c72c832fa8fcf09963f6f849