### PR TITLE
Improve offline resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The site registers a small service worker (`sw.js`) to cache static assets so
 that pages remain available when offline. Load the homepage once and it will
 work without a network connection. When offline, requests will show a lightweight offline page if the resource is unavailable. The service worker can be removed via your
 browser settings if needed.
+
+The homepage also caches the latest Nano price and network status in
+`localStorage`. When the APIs are unreachable, the last known values are shown
+with a `(cached)` label so the page still displays useful information even
+without connectivity.
 ## Desktop wallet
 See [linux-desktop](linux-desktop/) for an Electron-based desktop wallet and miner.
 The app now includes seed management, network selection on the settings page and a contacts view

--- a/js/network.js
+++ b/js/network.js
@@ -12,11 +12,26 @@ async function updateNetworkStatus() {
     });
     if (!resp.ok) throw new Error('network');
     const data = await resp.json();
+    const count = data.count;
     statusEl.textContent = 'online';
-    blockEl.textContent = data.count;
+    blockEl.textContent = count;
+    localStorage.setItem(
+      'network-status',
+      JSON.stringify({ status: 'online', count, ts: Date.now() }),
+    );
   } catch (err) {
     statusEl.textContent = 'offline';
-    blockEl.textContent = '-';
+    const cached = localStorage.getItem('network-status');
+    if (cached) {
+      try {
+        const { count } = JSON.parse(cached);
+        blockEl.textContent = `${count} (cached)`;
+      } catch {
+        blockEl.textContent = '-';
+      }
+    } else {
+      blockEl.textContent = '-';
+    }
   }
 }
 

--- a/js/price.js
+++ b/js/price.js
@@ -3,25 +3,44 @@ function updatePrice(value) {
   if (priceEl) priceEl.textContent = value;
 }
 
+async function fetchCoingeckoPrice() {
+  const resp = await fetch(
+    'https://api.coingecko.com/api/v3/simple/price?ids=nano&vs_currencies=usd',
+  );
+  if (!resp.ok) throw new Error('network');
+  const data = await resp.json();
+  return data.nano.usd.toFixed(2);
+}
+
+async function fetchFallbackPrice() {
+  const resp = await fetch(
+    'https://api.coinpaprika.com/v1/tickers/nano?quotes=USD',
+  );
+  if (!resp.ok) throw new Error('network');
+  const data = await resp.json();
+  return Number(data.quotes.USD.price).toFixed(2);
+}
+
 async function fetchPrice() {
   const priceEl = document.getElementById('nano-price');
   if (!priceEl) return;
+  priceEl.textContent = 'loading...';
   try {
-    priceEl.textContent = 'loading...';
-    const resp = await fetch(
-      'https://api.coingecko.com/api/v3/simple/price?ids=nano&vs_currencies=usd',
-    );
-    if (!resp.ok) throw new Error('network');
-    const data = await resp.json();
-    const price = data.nano.usd.toFixed(2);
+    const price = await fetchCoingeckoPrice();
     updatePrice(price);
     localStorage.setItem('nano-price', price);
   } catch (err) {
-    const cached = localStorage.getItem('nano-price');
-    if (cached) {
-      updatePrice(`${cached} (cached)`);
-    } else {
-      updatePrice('n/a');
+    try {
+      const price = await fetchFallbackPrice();
+      updatePrice(price);
+      localStorage.setItem('nano-price', price);
+    } catch (err2) {
+      const cached = localStorage.getItem('nano-price');
+      if (cached) {
+        updatePrice(`${cached} (cached)`);
+      } else {
+        updatePrice('n/a');
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- cache network status to show last known block count when offline
- add secondary price API for robustness
- mention cached data in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_688b98edd2c4832fb69a86c2c7acc33e