### PR TITLE
Add CI and improve service worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci --legacy-peer-deps
+      - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ version and rebuild the binary using the helper script:
 
 The script fetches the newest changes from the `nano-node` repository and
 recompiles the daemon in `nano-node/build`.
+
+## Continuous Integration
+A GitHub Actions workflow automatically runs ESLint on every push and pull
+request. This helps catch coding issues before changes are merged.

--- a/sw.js
+++ b/sw.js
@@ -22,13 +22,13 @@ self.addEventListener('install', (event) => {
 });
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
-        ),
-      ),
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+      );
+      await self.clients.claim();
+    })(),
   );
 });
 self.addEventListener('message', (event) => {


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run ESLint on every push and PR
- mention CI workflow in README
- claim clients during SW activation to ensure updates apply immediately

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bb424310c832fbada66df1265b461