### PR TITLE
Add offline banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ that pages remain available when offline. Load the homepage once and it will
 work without a network connection. When offline, requests will show a lightweight offline page if the resource is unavailable. The service worker can be removed via your
 browser settings if needed.
 
+An "offline" banner is displayed when the browser loses connectivity. It
+automatically hides again once the connection is restored.
+
 The homepage also caches the latest Nano price and network status in
 `localStorage`. When the APIs are unreachable, the last known values are shown
 with a `(cached)` label so the page still displays useful information even

--- a/css/styles.css
+++ b/css/styles.css
@@ -184,3 +184,16 @@ nav.uk-navbar-container a {
 nav.uk-navbar-container a:hover {
   color: #4a90e2;
 }
+
+.offline-banner {
+  display: none;
+  background: #e74c3c;
+  color: #fff;
+  text-align: center;
+  padding: 6px 0;
+  font-size: 0.8rem;
+}
+
+.offline-banner.show {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
         </ul>
       </div>
     </nav>
+    <div id="offline-banner" class="offline-banner">You are offline</div>
     <div id="holding" class="uk-section">
       <img src="img/nyano2.png" alt="nyano cat" width="300" />
       <h2 class="nyano">nyano</h2>
@@ -92,6 +93,7 @@
       defer
       src="node_modules/@fortawesome/fontawesome-free/js/all.min.js"
     ></script>
+    <script defer src="js/offline.js"></script>
     <script defer src="js/price.js"></script>
     <script defer src="js/network.js"></script>
     <script>

--- a/js/offline.js
+++ b/js/offline.js
@@ -1,0 +1,13 @@
+function updateOfflineBanner() {
+  const banner = document.getElementById('offline-banner');
+  if (!banner) return;
+  if (navigator.onLine) {
+    banner.classList.remove('show');
+  } else {
+    banner.classList.add('show');
+  }
+}
+
+window.addEventListener('online', updateOfflineBanner);
+window.addEventListener('offline', updateOfflineBanner);
+document.addEventListener('DOMContentLoaded', updateOfflineBanner);

--- a/offline.html
+++ b/offline.html
@@ -7,11 +7,13 @@
     <link rel="stylesheet" href="css/styles.css" />
   </head>
   <body>
+    <div id="offline-banner" class="offline-banner">You are offline</div>
     <div id="holding" class="uk-section">
       <h2 class="nyano">nyano</h2>
       <p>You appear to be offline. Some functionality may be unavailable.</p>
       <p>Please check your internet connection and try again.</p>
       <p><a href="/">Return to the homepage</a></p>
     </div>
+    <script defer src="js/offline.js"></script>
   </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -13,6 +13,7 @@ const ASSETS = [
   '/safari-pinned-tab.svg',
   '/js/price.js',
   '/js/network.js',
+  '/js/offline.js',
   '/css/Ubuntu-Title.woff2',
 ];
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- display an offline banner when the browser loses connectivity
- cache the new script via the service worker
- hook the banner into both the homepage and offline page
- document the feature in the README

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bb5f980ac832f8690abceb13b5e3a