### PR TITLE
Add RPC latency info on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,8 @@
         <p>Current Nano price: <span id="nano-price">-</span> USD</p>
         <p>
           Network status: <span id="network-status">-</span>, Blocks:
-          <span id="block-count">-</span>
+          <span id="block-count">-</span>, RPC latency:
+          <span id="network-latency">-</span>
         </p>
       </div>
     </div>

--- a/js/network.js
+++ b/js/network.js
@@ -1,36 +1,45 @@
 async function updateNetworkStatus() {
   const statusEl = document.getElementById('network-status');
   const blockEl = document.getElementById('block-count');
+  const latencyEl = document.getElementById('network-latency');
   if (!statusEl || !blockEl) return;
   try {
     statusEl.textContent = 'checking...';
     blockEl.textContent = '...';
+    if (latencyEl) latencyEl.textContent = '...';
+    const start = performance.now();
     const resp = await fetch('https://rpc.nyano.org', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'block_count' }),
     });
+    const latency = Math.round(performance.now() - start);
     if (!resp.ok) throw new Error('network');
     const data = await resp.json();
     const count = data.count;
     statusEl.textContent = 'online';
     blockEl.textContent = count;
+    if (latencyEl) latencyEl.textContent = `${latency} ms`;
     localStorage.setItem(
       'network-status',
-      JSON.stringify({ status: 'online', count, ts: Date.now() }),
+      JSON.stringify({ status: 'online', count, latency, ts: Date.now() }),
     );
   } catch (err) {
     statusEl.textContent = 'offline';
     const cached = localStorage.getItem('network-status');
     if (cached) {
       try {
-        const { count } = JSON.parse(cached);
+        const { count, latency } = JSON.parse(cached);
         blockEl.textContent = `${count} (cached)`;
+        if (latencyEl)
+          latencyEl.textContent = latency ? `${latency} ms (cached)` : '-';
       } catch {
         blockEl.textContent = '-';
+        if (latencyEl) latencyEl.textContent = '-';
       }
     } else {
       blockEl.textContent = '-';
+      if (latencyEl) latencyEl.textContent = '-';
     }
   }
 }


### PR DESCRIPTION
## Summary
- show RPC latency on the homepage
- cache latency value in `network-status`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bbf8d0184832fbea4c6b98e117c61