### PR TITLE
Add Nano wallet generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,17 @@ recompiles the daemon in `nano-node/build`.
 ## Continuous Integration
 A GitHub Actions workflow automatically runs ESLint on every push and pull
 request. This helps catch coding issues before changes are merged.
+
+## Generating a wallet
+You can generate a new Nano wallet from the command line using:
+
+```bash
+npm run generate-wallet
+```
+
+The command prints the seed and address to the console. Provide a file path to save the wallet as JSON:
+
+```bash
+npm run generate-wallet -- wallet.json
+```
+

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -14,6 +14,7 @@ function generateWallet() {
     );
   }
 }
+window.generateWallet = generateWallet;
 
 function copyToClipboard(text) {
   if (navigator.clipboard) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "nyano.org",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.15.4"
+    "@fortawesome/fontawesome-free": "5.15.4",
+    "nanocurrency": "^2.5.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",
@@ -21,7 +22,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint \"**/*.js\"",
     "format": "prettier \"**/*.{js,css,html}\" --write",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "generate-wallet": "node scripts/generate-wallet.js"
   },
   "repository": {
     "type": "git",
@@ -35,7 +37,12 @@
   },
   "homepage": "https://github.com/rickyhewitt/nyano#readme",
   "lint-staged": {
-    "*.js": ["prettier --write", "eslint"],
-    "*.{css,html}": ["prettier --write"]
+    "*.js": [
+      "prettier --write",
+      "eslint"
+    ],
+    "*.{css,html}": [
+      "prettier --write"
+    ]
   }
 }

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { generateSeed, deriveAddress } = require('nanocurrency');
+const fs = require('fs');
+const path = require('path');
+
+const seed = generateSeed();
+const address = deriveAddress(seed, 0, { prefix: 'nano_' });
+
+const data = { seed, address };
+const outPath = process.argv[2];
+
+if (outPath) {
+  const file = path.resolve(outPath);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  console.log(`Wallet written to ${file}`);
+} else {
+  console.log(`Seed: ${seed}`);
+  console.log(`Address: ${address}`);
+}

--- a/wallet.html
+++ b/wallet.html
@@ -35,7 +35,7 @@
       </p>
       <button id="download-btn" class="wallet-btn">Download Wallet</button>
       <button id="generate-btn" class="wallet-btn primary">
-        Generate New Wallet
+        Generate Nano Wallet
       </button>
     </div>
     <script src="js/nanocurrency.js"></script>


### PR DESCRIPTION
## Summary
- enable Nano wallet generation via CLI
- expose `generateWallet` function on wallet page
- update wallet page button text
- document wallet script usage in README
- include `nanocurrency` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(reports numerous style violations in bundled js)*

------
https://chatgpt.com/codex/tasks/task_e_688bd5688760832f9312e9edf846b24b