### PR TITLE
Improve wallet generation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+js/nanocurrency.js

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,0 +1,11 @@
+const { generateSeed, deriveAddress } = require('nanocurrency');
+const bip39 = require('bip39');
+
+function generateWallet(index = 0, prefix = 'nano_') {
+  const seed = generateSeed();
+  const mnemonic = bip39.entropyToMnemonic(seed);
+  const address = deriveAddress(seed, index, { prefix });
+  return { seed, mnemonic, address };
+}
+
+module.exports = { generateWallet };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "nyano.org",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
+    "bip39": "^3.1.0",
     "nanocurrency": "^2.5.0"
   },
   "devDependencies": {
@@ -11,9 +12,9 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-n": "^17.21.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
-    "eslint-plugin-n": "^17.21.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2"

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
-const { generateSeed, deriveAddress } = require('nanocurrency');
 const fs = require('fs');
 const path = require('path');
+const { generateWallet } = require('../lib/wallet');
 
-const seed = generateSeed();
-const address = deriveAddress(seed, 0, { prefix: 'nano_' });
-
-const data = { seed, address };
 const outPath = process.argv[2];
+const index = process.argv[3] ? parseInt(process.argv[3], 10) : 0;
+
+const { seed, mnemonic, address } = generateWallet(index);
+
+const data = { seed, mnemonic, address };
 
 if (outPath) {
   const file = path.resolve(outPath);
@@ -15,5 +16,6 @@ if (outPath) {
   console.log(`Wallet written to ${file}`);
 } else {
   console.log(`Seed: ${seed}`);
+  console.log(`Mnemonic: ${mnemonic}`);
   console.log(`Address: ${address}`);
 }


### PR DESCRIPTION
## Summary
- add simple `.eslintignore` to silence vendor lint errors
- implement library to generate seed, mnemonic, and address
- extend wallet generation script to output mnemonic as well
- add `bip39` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bd7d49a24832f9b2e8844d67a4e69