### PR TITLE
Enhance wallet backend functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You can also specify options:
 npm run generate-wallet -- --index 2 --prefix nyano_ --count 3
 npm run generate-wallet -- --seed <hex_seed> --count 2
 npm run generate-wallet -- --mnemonic "word list..."
+npm run generate-wallet -- --keys
 ```
 
 Run the wallet API server with:
@@ -167,10 +168,13 @@ Run the wallet API server with:
 npm run wallet-api
 ```
 
-It exposes two endpoints:
+It exposes several endpoints:
 
 - `GET /generate` – returns a new wallet. Optional query parameters `index`,
   `prefix` and `count` allow specifying the account index, address prefix and
   number of addresses to generate.
 - `POST /derive` – derive from a provided seed or mnemonic. Send `index`,
   `prefix` and `count` in the JSON body to control the derived addresses.
+- `POST /keys` – return the secret and public keys for a seed or mnemonic at a
+  given index.
+- `POST /validate` – validate a seed, mnemonic, address or secret key.

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -35,6 +35,20 @@ function derivePublicKeyFromSeed(seed, index = 0) {
   return derivePublicKey(secretKey);
 }
 
+function deriveSecretKeyFromMnemonic(mnemonic, index = 0) {
+  const seed = bip39.mnemonicToEntropy(mnemonic);
+  return deriveSecretKeyFromSeed(seed, index);
+}
+
+function derivePublicKeyFromMnemonic(mnemonic, index = 0) {
+  const seed = bip39.mnemonicToEntropy(mnemonic);
+  return derivePublicKeyFromSeed(seed, index);
+}
+
+function validateSecretKey(secretKey) {
+  return typeof secretKey === 'string' && /^[0-9A-Fa-f]{64}$/.test(secretKey);
+}
+
 function deriveAddresses(seed, count = 1, startIndex = 0, prefix = 'nano_') {
   const addresses = [];
   for (let i = 0; i < count; i++) {
@@ -61,6 +75,9 @@ module.exports = {
   deriveWalletFromMnemonic,
   deriveSecretKeyFromSeed,
   derivePublicKeyFromSeed,
+  deriveSecretKeyFromMnemonic,
+  derivePublicKeyFromMnemonic,
+  validateSecretKey,
   deriveAddresses,
   validateSeed,
   validateMnemonic,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "^3.6.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/wallet.test.js",
     "lint": "eslint \"**/*.js\"",
     "format": "prettier \"**/*.{js,css,html}\" --write",
     "prepare": "husky install",

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -6,12 +6,15 @@ const {
   deriveWalletFromSeed,
   deriveWalletFromMnemonic,
   deriveAddresses,
+  deriveSecretKeyFromSeed,
+  derivePublicKeyFromSeed,
 } = require('../lib/wallet');
 
 let outPath;
 let index = 0;
 let prefix = 'nano_';
 let count = 1;
+let showKeys = false;
 let seed;
 let mnemonic;
 
@@ -26,6 +29,9 @@ for (let i = 0; i < args.length; i++) {
       break;
     case '--count':
       count = parseInt(args[++i], 10);
+      break;
+    case '--keys':
+      showKeys = true;
       break;
     case '--seed':
       seed = args[++i];
@@ -59,7 +65,13 @@ async function main() {
     console.log(`Mnemonic: ${wallet.mnemonic}`);
     console.log(`Addresses:`);
     addresses.forEach((addr, i) => {
-      console.log(`  [${index + i}] ${addr}`);
+      const line = [`  [${index + i}] ${addr}`];
+      if (showKeys) {
+        const sk = deriveSecretKeyFromSeed(wallet.seed, index + i);
+        const pk = derivePublicKeyFromSeed(wallet.seed, index + i);
+        line.push(`\n    Secret: ${sk}\n    Public: ${pk}`);
+      }
+      console.log(line.join(''));
     });
   }
 }

--- a/scripts/wallet-server.js
+++ b/scripts/wallet-server.js
@@ -5,6 +5,14 @@ const {
   deriveWalletFromSeed,
   deriveWalletFromMnemonic,
   deriveAddresses,
+  deriveSecretKeyFromSeed,
+  derivePublicKeyFromSeed,
+  deriveSecretKeyFromMnemonic,
+  derivePublicKeyFromMnemonic,
+  validateSeed,
+  validateMnemonic,
+  validateAddress,
+  validateSecretKey,
 } = require('../lib/wallet');
 
 const app = express();
@@ -42,6 +50,37 @@ app.post('/derive', (req, res) => {
   } catch (err) {
     res.status(400).json({ error: 'invalid data' });
   }
+});
+
+app.post('/keys', (req, res) => {
+  const { seed, mnemonic } = req.body;
+  const index = req.body.index ? parseInt(req.body.index, 10) : 0;
+  try {
+    let secretKey;
+    let publicKey;
+    if (seed) {
+      secretKey = deriveSecretKeyFromSeed(seed, index);
+      publicKey = derivePublicKeyFromSeed(seed, index);
+    } else if (mnemonic) {
+      secretKey = deriveSecretKeyFromMnemonic(mnemonic, index);
+      publicKey = derivePublicKeyFromMnemonic(mnemonic, index);
+    } else {
+      return res.status(400).json({ error: 'seed or mnemonic required' });
+    }
+    res.json({ secretKey, publicKey });
+  } catch {
+    res.status(400).json({ error: 'invalid data' });
+  }
+});
+
+app.post('/validate', (req, res) => {
+  const { seed, mnemonic, address, secretKey } = req.body;
+  res.json({
+    seed: seed ? validateSeed(seed) : false,
+    mnemonic: mnemonic ? validateMnemonic(mnemonic) : false,
+    address: address ? validateAddress(address) : false,
+    secretKey: secretKey ? validateSecretKey(secretKey) : false,
+  });
 });
 
 const port = process.env.PORT || 3000;

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const wallet = require('../lib/wallet');
+
+async function run() {
+  const w = await wallet.generateWallet(0, 'nano_');
+  assert(wallet.validateSeed(w.seed));
+  assert(wallet.validateMnemonic(w.mnemonic));
+  assert(wallet.validateAddress(w.address));
+
+  const fromSeed = wallet.deriveWalletFromSeed(w.seed);
+  const fromMnemonic = wallet.deriveWalletFromMnemonic(w.mnemonic);
+  assert.strictEqual(fromSeed.address, w.address);
+  assert.strictEqual(fromMnemonic.address, w.address);
+
+  const sk = wallet.deriveSecretKeyFromMnemonic(w.mnemonic);
+  const pk = wallet.derivePublicKeyFromMnemonic(w.mnemonic);
+  assert(wallet.validateSecretKey(sk));
+  assert.strictEqual(typeof pk, 'string');
+
+  const addresses = wallet.deriveAddresses(w.seed, 2, 0, 'nano_');
+  assert.strictEqual(addresses.length, 2);
+
+  console.log('All wallet tests passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add ability to derive keys and validate data in wallet library
- expose new `/keys` and `/validate` endpoints in the wallet API server
- support showing keys in the CLI generator
- document additional options and endpoints
- add minimal test covering wallet functionality

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bdf589260832f96a3c595d43670bb