### PR TITLE
Add seed encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ npm run generate-wallet -- --index 2 --prefix nyano_ --count 3
 npm run generate-wallet -- --seed <hex_seed> --count 2
 npm run generate-wallet -- --mnemonic "word list..."
 npm run generate-wallet -- --keys
+npm run generate-wallet -- --password mypass -- wallet.json
 ```
+
+When providing a `--password`, the wallet seed is encrypted before being saved
+to disk or printed to the console.
 
 Run the wallet API server with:
 
@@ -177,4 +181,8 @@ It exposes several endpoints:
   `prefix` and `count` in the JSON body to control the derived addresses.
 - `POST /keys` – return the secret and public keys for a seed or mnemonic at a
   given index.
+- `POST /encrypt` – encrypt a seed with a password. Send `seed` and `password`
+  in the JSON body.
+- `POST /decrypt` – decrypt an encrypted seed using a password. Send
+  `encryptedSeed` and `password` in the JSON body.
 - `POST /validate` – validate a seed, mnemonic, address or secret key.

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -7,6 +7,7 @@ const {
   checkSeed,
 } = require('nanocurrency');
 const bip39 = require('bip39');
+const crypto = require('crypto');
 
 async function generateWallet(index = 0, prefix = 'nano_') {
   const seed = await generateSeed();
@@ -69,6 +70,30 @@ function validateAddress(address) {
   return checkAddress(address);
 }
 
+function encryptSeed(seed, password) {
+  const iv = crypto.randomBytes(12);
+  const key = crypto.createHash('sha256').update(password).digest();
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(seed, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('hex');
+}
+
+function decryptSeed(encryptedSeed, password) {
+  const data = Buffer.from(encryptedSeed, 'hex');
+  const iv = data.slice(0, 12);
+  const tag = data.slice(12, 28);
+  const enc = data.slice(28);
+  const key = crypto.createHash('sha256').update(password).digest();
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(enc), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
 module.exports = {
   generateWallet,
   deriveWalletFromSeed,
@@ -82,4 +107,6 @@ module.exports = {
   validateSeed,
   validateMnemonic,
   validateAddress,
+  encryptSeed,
+  decryptSeed,
 };

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -8,6 +8,7 @@ const {
   deriveAddresses,
   deriveSecretKeyFromSeed,
   derivePublicKeyFromSeed,
+  encryptSeed,
 } = require('../lib/wallet');
 
 let outPath;
@@ -17,6 +18,7 @@ let count = 1;
 let showKeys = false;
 let seed;
 let mnemonic;
+let password;
 
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i++) {
@@ -39,6 +41,9 @@ for (let i = 0; i < args.length; i++) {
     case '--mnemonic':
       mnemonic = args[++i];
       break;
+    case '--password':
+      password = args[++i];
+      break;
     default:
       if (!outPath) outPath = args[i];
   }
@@ -58,10 +63,19 @@ async function main() {
 
   if (outPath) {
     const file = path.resolve(outPath);
-    fs.writeFileSync(file, JSON.stringify({ ...wallet, addresses }, null, 2));
+    const data = { ...wallet, addresses };
+    if (password) {
+      data.encryptedSeed = encryptSeed(wallet.seed, password);
+      delete data.seed;
+    }
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
     console.log(`Wallet written to ${file}`);
   } else {
-    console.log(`Seed: ${wallet.seed}`);
+    if (password) {
+      console.log(`Encrypted Seed: ${encryptSeed(wallet.seed, password)}`);
+    } else {
+      console.log(`Seed: ${wallet.seed}`);
+    }
     console.log(`Mnemonic: ${wallet.mnemonic}`);
     console.log(`Addresses:`);
     addresses.forEach((addr, i) => {

--- a/scripts/wallet-server.js
+++ b/scripts/wallet-server.js
@@ -13,6 +13,8 @@ const {
   validateMnemonic,
   validateAddress,
   validateSecretKey,
+  encryptSeed,
+  decryptSeed,
 } = require('../lib/wallet');
 
 const app = express();
@@ -70,6 +72,34 @@ app.post('/keys', (req, res) => {
     res.json({ secretKey, publicKey });
   } catch {
     res.status(400).json({ error: 'invalid data' });
+  }
+});
+
+app.post('/encrypt', (req, res) => {
+  const { seed, password } = req.body;
+  if (!seed || !password) {
+    return res.status(400).json({ error: 'seed and password required' });
+  }
+  try {
+    const encryptedSeed = encryptSeed(seed, password);
+    res.json({ encryptedSeed });
+  } catch {
+    res.status(500).json({ error: 'encryption failed' });
+  }
+});
+
+app.post('/decrypt', (req, res) => {
+  const { encryptedSeed, password } = req.body;
+  if (!encryptedSeed || !password) {
+    return res
+      .status(400)
+      .json({ error: 'encryptedSeed and password required' });
+  }
+  try {
+    const seed = decryptSeed(encryptedSeed, password);
+    res.json({ seed });
+  } catch {
+    res.status(400).json({ error: 'decryption failed' });
   }
 });
 

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -20,6 +20,10 @@ async function run() {
   const addresses = wallet.deriveAddresses(w.seed, 2, 0, 'nano_');
   assert.strictEqual(addresses.length, 2);
 
+  const encrypted = wallet.encryptSeed(w.seed, 'pass');
+  const decrypted = wallet.decryptSeed(encrypted, 'pass');
+  assert.strictEqual(decrypted, w.seed);
+
   console.log('All wallet tests passed');
 }
 


### PR DESCRIPTION
## Summary
- provide optional wallet encryption functions
- support `--password` option in CLI wallet generator
- expose `/encrypt` and `/decrypt` endpoints in wallet API
- document usage of new functionality
- cover encryption in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be10c4a88832facf27de4fa68fe98