### PR TITLE
Implement BIP39 passphrase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You can also specify options:
 npm run generate-wallet -- --index 2 --prefix nyano_ --count 3
 npm run generate-wallet -- --seed <hex_seed> --count 2
 npm run generate-wallet -- --mnemonic "word list..."
+npm run generate-wallet -- --mnemonic "word list..." --passphrase myphrase
 npm run generate-wallet -- --keys
 npm run generate-wallet -- --password mypass -- wallet.json
 ```
@@ -178,9 +179,9 @@ It exposes several endpoints:
   `prefix` and `count` allow specifying the account index, address prefix and
   number of addresses to generate.
 - `POST /derive` – derive from a provided seed or mnemonic. Send `index`,
-  `prefix` and `count` in the JSON body to control the derived addresses.
+  `prefix`, `passphrase` and `count` in the JSON body to control the derived addresses.
 - `POST /keys` – return the secret and public keys for a seed or mnemonic at a
-  given index.
+  given index. Include `passphrase` if the mnemonic uses one.
 - `POST /encrypt` – encrypt a seed with a password. Send `seed` and `password`
   in the JSON body.
 - `POST /decrypt` – decrypt an encrypted seed using a password. Send

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -9,6 +9,16 @@ const {
 const bip39 = require('bip39');
 const crypto = require('crypto');
 
+function seedFromMnemonic(mnemonic, passphrase = '') {
+  if (passphrase) {
+    return bip39
+      .mnemonicToSeedSync(mnemonic, passphrase)
+      .slice(0, 32)
+      .toString('hex');
+  }
+  return bip39.mnemonicToEntropy(mnemonic);
+}
+
 async function generateWallet(index = 0, prefix = 'nano_') {
   const seed = await generateSeed();
   const mnemonic = bip39.entropyToMnemonic(seed);
@@ -22,8 +32,13 @@ function deriveWalletFromSeed(seed, index = 0, prefix = 'nano_') {
   return { seed, mnemonic, address };
 }
 
-function deriveWalletFromMnemonic(mnemonic, index = 0, prefix = 'nano_') {
-  const seed = bip39.mnemonicToEntropy(mnemonic);
+function deriveWalletFromMnemonic(
+  mnemonic,
+  index = 0,
+  prefix = 'nano_',
+  passphrase = '',
+) {
+  const seed = seedFromMnemonic(mnemonic, passphrase);
   return deriveWalletFromSeed(seed, index, prefix);
 }
 
@@ -36,13 +51,13 @@ function derivePublicKeyFromSeed(seed, index = 0) {
   return derivePublicKey(secretKey);
 }
 
-function deriveSecretKeyFromMnemonic(mnemonic, index = 0) {
-  const seed = bip39.mnemonicToEntropy(mnemonic);
+function deriveSecretKeyFromMnemonic(mnemonic, index = 0, passphrase = '') {
+  const seed = seedFromMnemonic(mnemonic, passphrase);
   return deriveSecretKeyFromSeed(seed, index);
 }
 
-function derivePublicKeyFromMnemonic(mnemonic, index = 0) {
-  const seed = bip39.mnemonicToEntropy(mnemonic);
+function derivePublicKeyFromMnemonic(mnemonic, index = 0, passphrase = '') {
+  const seed = seedFromMnemonic(mnemonic, passphrase);
   return derivePublicKeyFromSeed(seed, index);
 }
 
@@ -109,4 +124,5 @@ module.exports = {
   validateAddress,
   encryptSeed,
   decryptSeed,
+  seedFromMnemonic,
 };

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -19,6 +19,7 @@ let showKeys = false;
 let seed;
 let mnemonic;
 let password;
+let passphrase;
 
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i++) {
@@ -44,6 +45,9 @@ for (let i = 0; i < args.length; i++) {
     case '--password':
       password = args[++i];
       break;
+    case '--passphrase':
+      passphrase = args[++i];
+      break;
     default:
       if (!outPath) outPath = args[i];
   }
@@ -54,7 +58,7 @@ async function main() {
   if (seed) {
     wallet = deriveWalletFromSeed(seed, index, prefix);
   } else if (mnemonic) {
-    wallet = deriveWalletFromMnemonic(mnemonic, index, prefix);
+    wallet = deriveWalletFromMnemonic(mnemonic, index, prefix, passphrase);
   } else {
     wallet = await generateWallet(index, prefix);
   }

--- a/scripts/wallet-server.js
+++ b/scripts/wallet-server.js
@@ -34,7 +34,7 @@ app.get('/generate', async (req, res) => {
 });
 
 app.post('/derive', (req, res) => {
-  const { seed, mnemonic } = req.body;
+  const { seed, mnemonic, passphrase = '' } = req.body;
   const index = req.body.index ? parseInt(req.body.index, 10) : 0;
   const prefix = req.body.prefix || 'nano_';
   const count = req.body.count ? parseInt(req.body.count, 10) : 1;
@@ -43,7 +43,7 @@ app.post('/derive', (req, res) => {
     if (seed) {
       wallet = deriveWalletFromSeed(seed, index, prefix);
     } else if (mnemonic) {
-      wallet = deriveWalletFromMnemonic(mnemonic, index, prefix);
+      wallet = deriveWalletFromMnemonic(mnemonic, index, prefix, passphrase);
     } else {
       return res.status(400).json({ error: 'seed or mnemonic required' });
     }
@@ -55,7 +55,7 @@ app.post('/derive', (req, res) => {
 });
 
 app.post('/keys', (req, res) => {
-  const { seed, mnemonic } = req.body;
+  const { seed, mnemonic, passphrase = '' } = req.body;
   const index = req.body.index ? parseInt(req.body.index, 10) : 0;
   try {
     let secretKey;
@@ -64,8 +64,8 @@ app.post('/keys', (req, res) => {
       secretKey = deriveSecretKeyFromSeed(seed, index);
       publicKey = derivePublicKeyFromSeed(seed, index);
     } else if (mnemonic) {
-      secretKey = deriveSecretKeyFromMnemonic(mnemonic, index);
-      publicKey = derivePublicKeyFromMnemonic(mnemonic, index);
+      secretKey = deriveSecretKeyFromMnemonic(mnemonic, index, passphrase);
+      publicKey = derivePublicKeyFromMnemonic(mnemonic, index, passphrase);
     } else {
       return res.status(400).json({ error: 'seed or mnemonic required' });
     }

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -12,6 +12,17 @@ async function run() {
   assert.strictEqual(fromSeed.address, w.address);
   assert.strictEqual(fromMnemonic.address, w.address);
 
+  const fromMnemonicPass = wallet.deriveWalletFromMnemonic(
+    w.mnemonic,
+    0,
+    'nano_',
+    'passphrase',
+  );
+  const seedPass = wallet.seedFromMnemonic(w.mnemonic, 'passphrase');
+  const fromSeedPass = wallet.deriveWalletFromSeed(seedPass);
+  assert.strictEqual(fromMnemonicPass.address, fromSeedPass.address);
+  assert.notStrictEqual(fromMnemonicPass.address, w.address);
+
   const sk = wallet.deriveSecretKeyFromMnemonic(w.mnemonic);
   const pk = wallet.derivePublicKeyFromMnemonic(w.mnemonic);
   assert(wallet.validateSecretKey(sk));


### PR DESCRIPTION
## Summary
- add helper to derive seed from mnemonic with optional passphrase
- support `passphrase` in wallet CLI and API endpoints
- extend tests and docs for passphrase usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be34e44dc832f8d2b955a28738a6c