### PR TITLE
Limit service worker to same-origin GET requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -36,6 +36,10 @@ self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
 });
 self.addEventListener('fetch', (event) => {
+  // Only handle GET requests for same-origin resources
+  if (event.request.method !== 'GET') return;
+  if (new URL(event.request.url).origin !== self.location.origin) return;
+
   event.respondWith(
     fetch(event.request)
       .then((response) => {


### PR DESCRIPTION
## Summary
- Avoid caching cross-origin or non-GET requests by refining the service worker fetch handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e0ed4c38832f9e14154ef445ec41