### PR TITLE
fix: correct secret key public key derivation

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -79,6 +79,10 @@ function derivePublicKeyFromMnemonic(mnemonic, index = 0, passphrase = '') {
   return derivePublicKeyFromSeed(seed, index);
 }
 
+function derivePublicKeyFromSecretKey(secretKey) {
+  return derivePublicKey(secretKey);
+}
+
 function validateSecretKey(secretKey) {
   return typeof secretKey === 'string' && /^[0-9A-Fa-f]{64}$/.test(secretKey);
 }
@@ -187,6 +191,7 @@ module.exports = {
   derivePublicKeyFromSeed,
   deriveSecretKeyFromMnemonic,
   derivePublicKeyFromMnemonic,
+  derivePublicKeyFromSecretKey,
   validateSecretKey,
   deriveAddresses,
   validateSeed,

--- a/scripts/wallet-server.js
+++ b/scripts/wallet-server.js
@@ -10,6 +10,7 @@ const {
   deriveSecretKeyFromMnemonic,
   derivePublicKeyFromMnemonic,
   deriveWalletFromSecretKey,
+  derivePublicKeyFromSecretKey,
   validateSeed,
   validateMnemonic,
   validateAddress,
@@ -77,7 +78,7 @@ app.post('/keys', (req, res) => {
       publicKey = derivePublicKeyFromMnemonic(mnemonic, index, passphrase);
     } else if (secretKey) {
       sk = secretKey;
-      publicKey = derivePublicKeyFromSeed(secretKey, 0);
+      publicKey = derivePublicKeyFromSecretKey(secretKey);
     } else {
       return res
         .status(400)

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -27,6 +27,8 @@ async function run() {
   const pk = wallet.derivePublicKeyFromMnemonic(w.mnemonic);
   assert(wallet.validateSecretKey(sk));
   assert.strictEqual(typeof pk, 'string');
+  const pkFromSecret = wallet.derivePublicKeyFromSecretKey(sk);
+  assert.strictEqual(pkFromSecret, pk);
 
   const fromSecret = wallet.deriveWalletFromSecretKey(sk);
   assert.strictEqual(fromSecret.address, w.address);


### PR DESCRIPTION
## Summary
- allow deriving a public key directly from a secret key
- use the new helper in the wallet API server
- test secret key public key derivation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e2284550832fbadc0302bd97b746