### PR TITLE
feat: harden wallet api server

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Run the wallet API server with:
 npm run wallet-api
 ```
 
+The server enables CORS and sets common security headers so it can be safely
+accessed from browser-based clients. Unknown routes now return a `404` response
+and unexpected errors are handled gracefully.
+
 It exposes several endpoints:
 
 - `GET /generate` – returns a new wallet. Optional query parameters `index`,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
     "bip39": "^3.1.0",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
+    "helmet": "^7.0.0",
     "nanocurrency": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- allow wallet API to be used from browsers by enabling CORS and security headers
- add 404 and error handling to wallet API server
- document new server behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e3a8b9b4832f841760b8d157d8c0