### PR TITLE
feat: add JSON output option to wallet generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,14 @@ npm run generate-wallet -- --mnemonic "word list..." --passphrase myphrase
 npm run generate-wallet -- --keys
 npm run generate-wallet -- --password mypass -- wallet.json
 npm run generate-wallet -- --secret <secret_key>
+npm run generate-wallet -- --json
 ```
 
 When providing a `--password`, the wallet seed is encrypted before being saved
 to disk or printed to the console.
+
+Use the `--json` flag to output the wallet details and derived addresses as
+JSON, which is helpful for programmatic usage or further processing.
 
 Run the wallet API server with:
 

--- a/scripts/generate-wallet.js
+++ b/scripts/generate-wallet.js
@@ -24,6 +24,7 @@ let mnemonic;
 let secretKey;
 let password;
 let passphrase;
+let jsonOutput = false;
 
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i++) {
@@ -39,6 +40,9 @@ for (let i = 0; i < args.length; i++) {
       break;
     case '--keys':
       showKeys = true;
+      break;
+    case '--json':
+      jsonOutput = true;
       break;
     case '--load':
       loadPath = args[++i];
@@ -81,11 +85,18 @@ async function main() {
   const addresses = wallet.seed
     ? deriveAddresses(wallet.seed, count, index, prefix)
     : [wallet.address];
+  const output = { ...wallet, addresses };
 
   if (outPath) {
     const file = path.resolve(outPath);
-    saveWalletToFile({ ...wallet, addresses }, file, password);
-    console.log(`Wallet written to ${file}`);
+    saveWalletToFile(output, file, password);
+    if (jsonOutput) {
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      console.log(`Wallet written to ${file}`);
+    }
+  } else if (jsonOutput) {
+    console.log(JSON.stringify(output, null, 2));
   } else {
     if (wallet.seed) {
       if (password) {

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -55,6 +55,20 @@ async function run() {
   assert.strictEqual(loaded2.address, w.address);
   fs.unlinkSync(file2);
 
+  const { spawnSync } = require('child_process');
+  const cli = spawnSync('node', ['scripts/generate-wallet.js', '--json'], {
+    encoding: 'utf8',
+  });
+  if (cli.status !== 0) throw new Error(cli.stderr);
+  const cliWallet = JSON.parse(cli.stdout);
+  assert(wallet.validateAddress(cliWallet.address));
+  if (cliWallet.seed) {
+    assert(wallet.validateSeed(cliWallet.seed));
+  } else {
+    assert(wallet.validateSecretKey(cliWallet.secretKey));
+  }
+  assert(Array.isArray(cliWallet.addresses));
+
   console.log('All wallet tests passed');
 }
 


### PR DESCRIPTION
## Summary
- support `--json` flag in wallet generator to output wallet details and addresses as JSON
- cover CLI JSON output with tests
- document new `--json` option in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e57e0fbc832f9982e776055100c2