### PR TITLE
feat: show active network in header

### DIFF
--- a/linux-desktop/index.html
+++ b/linux-desktop/index.html
@@ -15,6 +15,7 @@
         <i class="fas fa-bars"></i>
       </button>
       <h1>Nyano Desktop</h1>
+      <span id="header-network" class="network-indicator"></span>
     </header>
     <nav id="sidebar">
       <ul>

--- a/linux-desktop/renderer.js
+++ b/linux-desktop/renderer.js
@@ -96,6 +96,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   const unlockWalletBtn = document.getElementById('unlock-wallet');
   const networkSelect = document.getElementById('network-select');
   const currentNetworkEl = document.getElementById('current-network');
+  const headerNetworkEl = document.getElementById('header-network');
   const rpcInput = document.getElementById('rpc-url');
   const saveRpcBtn = document.getElementById('save-rpc');
   const indexInput = document.getElementById('account-index');
@@ -171,6 +172,10 @@ window.addEventListener('DOMContentLoaded', async () => {
   const storedNetwork = localStorage.getItem('network') || 'mainnet';
   if (networkSelect) networkSelect.value = storedNetwork;
   if (currentNetworkEl) currentNetworkEl.textContent = storedNetwork;
+  if (headerNetworkEl) {
+    headerNetworkEl.textContent = storedNetwork;
+    headerNetworkEl.className = `network-indicator ${storedNetwork}`;
+  }
   if (rpcInput) rpcInput.value = getStoredRpc(storedNetwork);
   const storedIndex = parseInt(localStorage.getItem('accountIndex') || '0', 10);
   if (indexInput) indexInput.value = storedIndex;
@@ -353,6 +358,10 @@ window.addEventListener('DOMContentLoaded', async () => {
           localStorage.setItem('network', data.network);
           if (networkSelect) networkSelect.value = data.network;
           if (currentNetworkEl) currentNetworkEl.textContent = data.network;
+          if (headerNetworkEl) {
+            headerNetworkEl.textContent = data.network;
+            headerNetworkEl.className = `network-indicator ${data.network}`;
+          }
         }
         if (data.rpcUrls && typeof data.rpcUrls === 'object') {
           Object.keys(NETWORK_RPC_DEFAULTS).forEach((net) => {
@@ -402,6 +411,10 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (seedInput) seedInput.disabled = false;
     if (networkSelect) networkSelect.value = 'mainnet';
     if (currentNetworkEl) currentNetworkEl.textContent = 'mainnet';
+    if (headerNetworkEl) {
+      headerNetworkEl.textContent = 'mainnet';
+      headerNetworkEl.className = 'network-indicator mainnet';
+    }
     if (rpcInput) rpcInput.value = NETWORK_RPC_DEFAULTS.mainnet;
     if (autoStartNodeToggle) autoStartNodeToggle.checked = false;
     accountIndex = 0;
@@ -422,6 +435,10 @@ window.addEventListener('DOMContentLoaded', async () => {
       const net = networkSelect.value;
       localStorage.setItem('network', net);
       if (currentNetworkEl) currentNetworkEl.textContent = net;
+      if (headerNetworkEl) {
+        headerNetworkEl.textContent = net;
+        headerNetworkEl.className = `network-indicator ${net}`;
+      }
       if (rpcInput) rpcInput.value = getStoredRpc(net);
     });
   }

--- a/linux-desktop/styles.css
+++ b/linux-desktop/styles.css
@@ -55,6 +55,29 @@ header h1 {
   margin: 0;
 }
 
+.network-indicator {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: #444;
+  font-size: 0.8rem;
+  text-transform: capitalize;
+}
+
+.network-indicator.mainnet {
+  background: #2e7d32;
+  color: #fff;
+}
+
+.network-indicator.testnet {
+  background: #ef6c00;
+  color: #fff;
+}
+
+.network-indicator.beta {
+  background: #6a1b9a;
+  color: #fff;
+}
+
 .dark header {
   background-color: #000;
 }


### PR DESCRIPTION
## Summary
- show active network at top of desktop wallet
- style network indicator and keep it synced with current network

## Testing
- `npm test`
- `npm run lint`
- `cd linux-desktop && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68911e6f4b30832f922e563f7feb49ce