### PR TITLE
feat(wallet): allow entering an existing seed

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -224,3 +224,22 @@ nav.uk-navbar-container a:hover {
 .wallet-generator .wallet-btn.primary {
   background: #3379ca;
 }
+
+.wallet-input {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+  background: #1b1b1e;
+  color: #b5b5c8;
+  border: 1px solid #4a90e2;
+  border-radius: 4px;
+  font-family: 'Open Sans', Arial, sans-serif;
+}
+
+.error-message {
+  color: #ff6b6b;
+  font-size: 0.8rem;
+  height: 1em;
+  margin-bottom: 8px;
+}

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -1,7 +1,25 @@
 /* global QRCode */
 const { generateSeed, deriveAddress } = window.nanocurrency;
+
+function showError(msg) {
+  document.getElementById('seed-error').textContent = msg;
+}
+
 async function generateWallet() {
-  const seed = await generateSeed();
+  const seedInput = document.getElementById('seed-input').value.trim();
+  let seed;
+  if (seedInput) {
+    if (/^[0-9a-fA-F]{64}$/.test(seedInput)) {
+      seed = seedInput.toUpperCase();
+      showError('');
+    } else {
+      showError('Seed must be 64 hex characters.');
+      return;
+    }
+  } else {
+    seed = await generateSeed();
+    showError('');
+  }
   const address = deriveAddress(seed, 0, { prefix: 'nano_' });
   document.getElementById('seed').textContent = seed;
   document.getElementById('address').textContent = address;

--- a/wallet.html
+++ b/wallet.html
@@ -24,6 +24,17 @@
         Your new seed and first Nano address are shown below. Store the seed
         securely.
       </p>
+      <div class="wallet-input-group">
+        <label for="seed-input">Existing Seed (optional):</label>
+        <input
+          id="seed-input"
+          class="wallet-input"
+          type="text"
+          maxlength="64"
+          placeholder="64-character seed"
+        />
+        <div id="seed-error" class="error-message"></div>
+      </div>
       <canvas id="address-qr" width="192" height="192"></canvas>
       <p>
         <strong>Seed:</strong> <span id="seed"></span>


### PR DESCRIPTION
## Summary
- let users optionally input an existing seed to derive a wallet
- validate custom seed format and show error messages
- style input and error message elements

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689120278998832faf013835b9391efe